### PR TITLE
[QTI-78] Add Vault verify license smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@
 # Crash log files
 crash.log
 
-# Exclude all .tfvars files
-*.tfvars
-
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc

--- a/workspaces/vault-smoke/.gitignore
+++ b/workspaces/vault-smoke/.gitignore
@@ -1,0 +1,3 @@
+terraform-plugin-cache
+*.pem
+*.hclic

--- a/workspaces/vault-smoke/Makefile
+++ b/workspaces/vault-smoke/Makefile
@@ -1,0 +1,19 @@
+default: init run destroy
+
+init: verify-license-init
+run: verify-license-run
+destroy: verify-license-destroy
+
+verify-license-init:
+	export TF_CLI_CONFIG_FILE=./mirror.tfrc &&\
+	mkdir -p ./terraform-plugin-cache && \
+	terraform -chdir=./scenarios/verify-license init -upgrade -var-file=../../terraform.tfvars &&\
+	chmod -R +x ./terraform-plugin-cache/hashicorp.com/qti/enos/*
+
+verify-license-run:
+	export TF_CLI_CONFIG_FILE=./mirror.tfrc &&\
+	terraform -chdir=./scenarios/verify-license apply -var-file=../../terraform.tfvars -auto-approve
+
+verify-license-destroy:
+	export TF_CLI_CONFIG_FILE=./mirror.tfrc &&\
+	terraform -chdir=./scenarios/verify-license destroy -var-file=../../terraform.tfvars -auto-approve

--- a/workspaces/vault-smoke/README.md
+++ b/workspaces/vault-smoke/README.md
@@ -1,0 +1,49 @@
+# Vault Enterprise smoke tests
+
+Here you'll find the Vault Enterprise smoke tests. All of these smoke tests are
+designed to create Vault clusters from staged Vault Enterprise artifacts and run
+various test scenarios. All tests are written as Terraform using the the
+[enos Terraform provider](https://github.com/hashicorp/enos-provider) to dynamically
+configure instances, perform lifecycle events, and test for various conditions.
+
+## Requirements
+
+1. Terraform v0.15.0 or higher.
+1. `make`.
+1. Access to an AWS account and an AWS SSH key pair.
+1. Access to Artifactory and an Artifactory token.
+1. Access to the hashicorp-qti TFC org to access the enos Terraform modules.
+  You can find the `vault` team token in 1Password as `hashicorp-qti HCP Token`.
+
+## Setup
+
+1. Use `doormat` to create temporary AWS credentials and set up the AWS credential
+  chain in your preferred way.
+1. Update [terraform.tfvars](./terraform.tfvars) with your Artifactory username
+  and token. Your artifactory username will be your HashiCorp email address. If you
+  don't have a token you can generate one [here](https://artifactory.hashicorp.engineering/ui/admin/artifactory/user_profile).
+1. Update the `productRevision` and `productVersion` variables in [terraform.tfvars](.terraform.tfvars)
+  with the git SHA of the staged build you wish to test and its corresponding
+  version.
+1. Update [terraform.tfvars](./terraform.tfvars) with your AWS key pair name
+  and the path to the private key on your machine. If you don't have an AWS key
+  pair you can use `doormat --aws console` to login to the AWS console and generate
+  one. Make sure the AWS key pair is in the same region that you've configured in
+  [terraform.tfvars](./terraform.tfvars).
+1. Update the [mirror.tfrc](./mirror.tfrc) Terraform CLI config file with the hashicorp-qti
+  `vault` team token. You can find it in 1Password as `hashicorp-qti HCP Token`.
+
+## Run the smoke tests
+
+All of the test scenarios are defined in their own sub-directory that includes the
+Terraform HCL that defines the test case. If you wish to override a default variable in the
+test case you should set it in the [terraform.tfvars](./terraform.tfvars) file.
+
+To execute all tests and cleanup after, run `make`.
+
+To run an individual test:
+1. Initialize it. You only need to do this once. `make test-name-init`
+1. Run it. `make test-name-run`
+1. Destroy it. `make test-name-destroy`
+
+Consult the [Makefile](./Makefile) to which test targets are available.

--- a/workspaces/vault-smoke/mirror.tfrc
+++ b/workspaces/vault-smoke/mirror.tfrc
@@ -1,0 +1,17 @@
+plugin_cache_dir = "$PWD/terraform-plugin-cache"
+
+provider_installation {
+  network_mirror {
+    url = "https://enos-provider.s3-us-west-2.amazonaws.com/"
+    include = ["hashicorp.com/qti/enos"]
+  }
+  direct {
+    exclude = [
+      "hashicorp.com/qti/enos"
+    ]
+  }
+}
+
+credentials "app.terraform.io" {
+  token = "<your-hashicorp-qti-TFC-token>"
+}

--- a/workspaces/vault-smoke/scenarios/verify-license/main.tf
+++ b/workspaces/vault-smoke/scenarios/verify-license/main.tf
@@ -1,0 +1,140 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    enos = {
+      version = ">= 0.1.1"
+      source  = "hashicorp.com/qti/enos"
+    }
+  }
+}
+
+provider "enos" {
+  transport = {
+    ssh = {
+      # You can also override any of the transport settings from the environment,
+      # e.g.: ENOS_TRANSPORT_PRIVATE_KEY_PATH=/path/to/key.pem
+      user             = "ubuntu"
+      private_key_path = var.aws_ssh_private_key_path
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = var.aws_region
+}
+
+# Build our core infrastructure
+module "enos_infra" {
+  source  = "app.terraform.io/hashicorp-qti/aws-infra/enos"
+  version = "0.0.1"
+
+  project_name      = var.project_name
+  environment       = var.environment
+  common_tags       = var.common_tags
+  availability_zone = var.aws_availability_zone
+}
+
+# Find the staged build in artifactory
+data "enos_artifactory_item" "vault" {
+  username   = var.vault_artifactory_release.username
+  token      = var.vault_artifactory_release.token
+  host       = var.vault_artifactory_release.host
+  repo       = var.vault_artifactory_release.repo
+  path       = var.vault_artifactory_release.path
+  name       = var.vault_artifactory_release.name
+  properties = var.vault_artifactory_release.properties
+}
+
+# Build the Consul backend
+module "consul_cluster" {
+  # source  = "../../../../../terraform-enos-aws-consul"
+  source  = "app.terraform.io/hashicorp-qti/aws-consul/enos"
+  version = "0.1.6"
+
+  depends_on = [module.enos_infra]
+
+  project_name      = var.project_name
+  environment       = var.environment
+  common_tags       = var.common_tags
+
+  ssh_aws_keypair    = var.aws_ssh_key_pair_name
+  ubuntu_ami_id      = module.enos_infra.ubuntu_ami_id
+  vpc_id             = module.enos_infra.vpc_id
+  availability_zone  = var.aws_availability_zone
+  kms_key_arn        = module.enos_infra.kms_key_arn
+  consul_install_dir = var.consul_install_dir
+  consul_license     = var.consul_license_path != null ? file(var.consul_license_path) : null
+  consul_release     = var.consul_release
+}
+
+# Build the Vault cluster
+# Note: we don't set a license for this Vault cluster because the verify license
+# smoke tests # are designed to verify the default license.
+module "vault_cluster" {
+  #source  = "../../../../../terraform-enos-aws-vault"
+  source  = "app.terraform.io/hashicorp-qti/aws-vault/enos"
+  version = "0.0.6"
+
+  depends_on = [
+    module.enos_infra,
+    module.consul_cluster,
+  ]
+
+  project_name              = var.project_name
+  environment               = var.environment
+  common_tags               = var.common_tags
+  ssh_aws_keypair           = var.aws_ssh_key_pair_name
+  ubuntu_ami_id             = module.enos_infra.ubuntu_ami_id
+  vpc_id                    = module.enos_infra.vpc_id
+  kms_key_arn               = module.enos_infra.kms_key_arn
+  instance_count            = var.vault_instance_count
+  consul_ips                = module.consul_cluster.instance_private_ips
+  vault_license             = var.vault_license_path != null ? file(var.vault_license_path) : null
+  vault_install_dir         = var.vault_install_dir
+  vault_release             = null
+  vault_artifactory_release = {
+    url      = data.enos_artifactory_item.vault.results[0].url
+    sha256   = data.enos_artifactory_item.vault.results[0].sha256
+    username = var.vault_artifactory_release.username
+    token    = var.vault_artifactory_release.token
+  }
+}
+
+# Run the smoke tests
+resource "enos_remote_exec" "smoke-verify-license" {
+  depends_on = [module.vault_cluster]
+  for_each   = toset([for idx in range(var.vault_instance_count) : tostring(idx)])
+
+  content = templatefile("${path.module}/templates/smoke-verify-license.sh", {
+    vault_install_dir = var.vault_install_dir,
+    vault_token       = module.vault_cluster.vault_root_token,
+    vault_version     = var.vault_artifactory_release.properties["productVersion"]
+    vault_edition     = var.vault_artifactory_release.properties["EDITION"]
+  })
+
+  transport = {
+    ssh = {
+      host = module.vault_cluster.instance_public_ips[tonumber(each.value)]
+    }
+  }
+}
+
+resource "enos_remote_exec" "smoke-write-test-data" {
+  depends_on = [enos_remote_exec.smoke-verify-license]
+
+  content = templatefile("${path.module}/templates/smoke-write-test-data.sh", {
+    test_key          = "smoke"
+    test_value        = "fire"
+    vault_install_dir = var.vault_install_dir,
+    vault_token       = module.vault_cluster.vault_root_token,
+  })
+
+  transport = {
+    ssh = {
+      host = module.vault_cluster.instance_public_ips[0]
+    }
+  }
+}

--- a/workspaces/vault-smoke/scenarios/verify-license/outputs.tf
+++ b/workspaces/vault-smoke/scenarios/verify-license/outputs.tf
@@ -1,0 +1,46 @@
+output "consul_instance_ids" {
+  description = "IDs of Consul instances"
+  value       = module.consul_cluster.instance_ids
+}
+
+output "consul_instance_private_ips" {
+  description = "Private IPs of Consul instances"
+  value       = module.consul_cluster.instance_private_ips
+}
+
+output "consul_instance_public_ips" {
+  description = "Public IPs of Consul instances"
+  value       = module.consul_cluster.instance_public_ips
+}
+
+output "vault_instance_ids" {
+  description = "IDs of vault instances"
+  value       = module.vault_cluster.instance_ids
+}
+
+output "vault_instance_private_ips" {
+  description = "Private IPs of Vault instances"
+  value       = module.vault_cluster.instance_private_ips
+}
+
+output "vault_instance_public_ips" {
+  description = "Public IPs of Vault instances"
+  value       = module.vault_cluster.instance_public_ips
+}
+
+output "vault_root_token" {
+  description = "The Vault cluster root token. Keep it secret. Keep it safe."
+  value       = module.vault_cluster.vault_root_token
+}
+
+output "vault_recovery_keys_b64" {
+  description = "The Vault cluster recovery keys. Keep them secret. Keep them safe."
+  value       = module.vault_cluster.vault_recovery_keys_b64
+}
+
+output "vault_artifactory_release" {
+  value = {
+    url = data.enos_artifactory_item.vault.results[0].url
+    sha256 = data.enos_artifactory_item.vault.results[0].sha256
+  }
+}

--- a/workspaces/vault-smoke/scenarios/verify-license/templates/smoke-verify-license.sh
+++ b/workspaces/vault-smoke/scenarios/verify-license/templates/smoke-verify-license.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# The Vault smoke test. This is a modified version of the license checking script
+# https://github.com/hashicorp/vault-enterprise/blob/master/scripts/testing/test-vault-license.sh
+
+set -e
+
+function retry {
+  local retries=$1
+  shift
+  local count=0
+
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** count))
+    count=$((count + 1))
+    if [ "$count" -lt "$retries" ]; then
+      sleep "$wait"
+    else
+      return "$exit"
+    fi
+  done
+
+  return 0
+}
+
+echo "Installing required package(s) for the smoke test"
+# Make sure cloud-init is not modifying our sources list while we're trying
+# to install jq.
+retry 5 grep ec2 /etc/apt/sources.list
+
+cd /tmp
+retry 5 sudo apt update
+retry 5 sudo apt install -y jq
+
+fail() {
+	echo "$1" 1>&2
+	exit 1
+}
+
+binpath=${vault_install_dir}/vault
+edition=${vault_edition}
+version=${vault_version}
+release="$version+$edition"
+
+license_expected="temporary"
+case "$release" in
+	*+ent) ;;
+	*+ent.hsm) ;;
+	*+pro) license_expected="permanent";;
+	*+prem.hsm) license_expected="permanent";;
+	*+prem) license_expected="permanent";;
+  *) fail "($release) file doesn't match any known license types"
+esac
+
+features_expected=""
+case "$release" in
+	*1.2.*+ent*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP"]';;
+	*1.3.*+ent*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation"]';;
+	*1.4.*+ent*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation", "Transform Secrets Engine"]';;
+	*1.5.*+ent*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation", "Transform Secrets Engine", "Lease Count Quotas"]';;
+	*1.[6-8].*+ent*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation", "Transform Secrets Engine", "Lease Count Quotas", "Key Management Secrets Engine", "Automated Snapshots"]';;
+
+	*1.[2-4].*+pro_*) features_expected='["DR Replication", "Performance Standby", "Namespaces"]';;
+	*1.5.*+pro_*) features_expected='["DR Replication", "Performance Standby", "Namespaces", "Lease Count Quotas"]';;
+	*1.[6-8].*+pro_*) features_expected='["DR Replication", "Performance Standby", "Namespaces", "Lease Count Quotas", "Automated Snapshots"]';;
+
+	*1.2.*+prem*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP"]';;
+	*1.[3-4].*+prem*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation"]';;
+	*1.5.*+prem*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation", "Lease Count Quotas"]';;
+	*1.[6-8].*+prem*) features_expected='["HSM", "Performance Replication", "DR Replication", "MFA", "Sentinel", "Seal Wrapping", "Control Groups", "Performance Standby", "Namespaces", "KMIP", "Entropy Augmentation", "Lease Count Quotas", "Automated Snapshots"]';;
+
+	*) fail "zip file doesn't match any known feature types"
+esac
+
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+export VAULT_TOKEN='${vault_token}'
+retry 5 "$binpath" status > /dev/null 2>&1
+
+license_id=$("$binpath" read -format=json sys/license | jq -Mr .data.license_id)
+test "$license_id" = "$license_expected" || fail "expected license_id=$license_expected, got: $license_id"
+
+test true == $("$binpath" read -format=json sys/license | jq -Mr --argjson expected "$features_expected" '.data.features == $expected') ||
+	fail "expected features=$features_expected, got: $("$binpath" read -format=json sys/license | jq -Mr '.data.features')"

--- a/workspaces/vault-smoke/scenarios/verify-license/templates/smoke-write-test-data.sh
+++ b/workspaces/vault-smoke/scenarios/verify-license/templates/smoke-write-test-data.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+function retry {
+  local retries=$1
+  shift
+  local count=0
+
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** count))
+    count=$((count + 1))
+    if [ "$count" -lt "$retries" ]; then
+      sleep "$wait"
+    else
+      return "$exit"
+    fi
+  done
+
+  return 0
+}
+
+function fail {
+	echo "$1" 1>&2
+	exit 1
+}
+
+binpath=${vault_install_dir}/vault
+testkey=${test_key}
+testvalue=${test_value}
+
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+export VAULT_TOKEN='${vault_token}'
+
+retry 5 "$binpath" status > /dev/null 2>&1
+retry 5 $binpath secrets enable -path="secret" kv
+retry 5 $binpath kv put secret/test $testkey=$testvalue

--- a/workspaces/vault-smoke/scenarios/verify-license/variables.tf
+++ b/workspaces/vault-smoke/scenarios/verify-license/variables.tf
@@ -1,0 +1,98 @@
+variable "aws_region" {
+  description = "AWS default Region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_availability_zone" {
+  description = "AWS availability zone"
+  type        = string
+  default     = "us-east-1a"
+}
+
+variable "aws_ssh_key_pair_name" {
+  description = "SSH key pair used to connect to EC2 instances"
+  type        = string
+}
+
+variable "aws_ssh_private_key_path" {
+  description = "The path to the private key of the key pair used to connect to EC2 instances"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the project."
+  type        = string
+  default     = "vault-enterprise-smoke-verify-license"
+}
+
+variable "environment" {
+  description = "Name of the environment."
+  type        = string
+  default     = "dev"
+}
+
+variable "common_tags" {
+  description = "Tags to set for all resources"
+  type        = map(string)
+  default = {
+    "Project Name" : "vault-enterprise-smoke-verify-license",
+    "Environment" : "dev"
+  }
+}
+
+variable "consul_install_dir" {
+  type        = string
+  description = "The directory where the Consul binary will be installed"
+  default     = "/opt/consul/bin"
+}
+
+variable "consul_release" {
+  type = object({
+    version = string
+    edition = string
+  })
+  description = "Consul release version and edition to install from releases.hashicorp.com"
+  default = {
+    version = "1.9.5"
+    edition = "oss"
+  }
+}
+
+variable "consul_license_path" {
+  type        = string
+  description = "The path to the Consul Enterprise license if using the ent edition"
+  default     = null
+}
+
+variable "vault_install_dir" {
+  type        = string
+  description = "The directory where the Vault binary will be installed"
+  default     = "/opt/vault/bin"
+}
+
+variable "vault_license_path" {
+  type        = string
+  description = "The path to the Vault Enterprise license if using the ent edition"
+  default     = null
+}
+
+variable "vault_instance_count" {
+  type = number
+  description = "The number of instances to provision for Vault"
+  default = 3
+}
+
+variable "vault_artifactory_release" {
+  type = object({
+    username = string
+    token = string
+    host = string
+    repo = string
+    path = string
+    name = string
+    properties = map(string)
+  })
+  description = "Vault release version and edition to install from artifactory.hashicorp.engineering"
+  default = null
+}

--- a/workspaces/vault-smoke/terraform.tfvars
+++ b/workspaces/vault-smoke/terraform.tfvars
@@ -1,0 +1,32 @@
+aws_region               = "us-east-1"
+aws_availability_zone    = "us-east-1a"
+aws_ssh_key_pair_name    = "<your-aws-ssh-key-pair-name>"
+aws_ssh_private_key_path = "</path/to/your/ssh/private/key.pem>"
+
+vault_install_dir         = "/opt/vault/bin"
+vault_instance_count      = 3
+vault_license_path        = null
+vault_artifactory_release = {
+  username   = "<your-email@hashicorp.com>"
+  token      = "<your-artifactory-token>"
+  host       = "https://artifactory.hashicorp.engineering/artifactory"
+  repo       = "hashicorp-packagespec-buildcache-local*"
+  path       = "cache-v1/vault-enterprise/*"
+  name       = "*.zip"
+  properties = {
+    "EDITION"         = "ent"
+    "GOARCH"          = "amd64"
+    "GOOS"            = "linux"
+    "artifactType"    = "package"
+    # productRevision should be the git SHA of the staged release
+    "productRevision" = "f45845666b4e552bfc8ca775834a3ef6fc097fe0"
+    "productVersion"  = "1.7.0" # this is required for the smoke test
+  }
+}
+
+# Consul cluster
+consul_license_path = null # only required for "ent" edition
+consul_release = {
+  version = "1.9.5"
+  edition = "oss"
+}


### PR DESCRIPTION
* Add Vault Enterprise smoke test that deploys a staged release in
  Artifactory to a 3 node Vault/Consul cluster and verifies the default
  license.
* Add Makefile and mirror.tfrc to ease with executing the smoke tests.
* Add README that explains how to setup and execute the smoke tests.

Signed-off-by: Ryan Cragun <me@ryan.ec>