### PR TITLE
[QTI-148] Add module references to scenario steps

### DIFF
--- a/internal/command/enos/cmd/integration_tests/scenario_list_pass_1/enos.hcl
+++ b/internal/command/enos/cmd/integration_tests/scenario_list_pass_1/enos.hcl
@@ -1,2 +1,9 @@
+module "consul" {
+  source = "hashicorp/consul/aws"
+}
+
 scenario "test" {
+  step "backend" {
+    module = module.consul
+  }
 }

--- a/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-1.hcl
+++ b/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-1.hcl
@@ -1,2 +1,0 @@
-scenario "one" {
-}

--- a/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-2.hcl
+++ b/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-2.hcl
@@ -1,2 +1,0 @@
-scenario "two" {
-}

--- a/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-consul.hcl
+++ b/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-consul.hcl
@@ -1,0 +1,5 @@
+scenario "consul" {
+  step "test" {
+    module = module.consul
+  }
+}

--- a/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-modules.hcl
+++ b/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-modules.hcl
@@ -1,0 +1,7 @@
+module "consul" {
+  source = "hashicorp/consul/aws"
+}
+
+module "vault" {
+  source = "hashicorp/vault/aws"
+}

--- a/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-vault.hcl
+++ b/internal/command/enos/cmd/integration_tests/scenario_list_pass_2/enos-vault.hcl
@@ -1,0 +1,5 @@
+scenario "vault" {
+  step "test" {
+    module = module.vault
+  }
+}

--- a/internal/command/enos/cmd/scenario_list.go
+++ b/internal/command/enos/cmd/scenario_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -50,6 +51,9 @@ func runScenarioListCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fp.Scenarios) != 0 {
+		sort.Slice(fp.Scenarios, func(i, j int) bool {
+			return fp.Scenarios[i].Name < fp.Scenarios[j].Name
+		})
 		header := []string{"scenario"}
 		rows := [][]string{{""}} // add a padding row
 		for _, scenario := range fp.Scenarios {

--- a/internal/command/enos/cmd/scenario_list_test.go
+++ b/internal/command/enos/cmd/scenario_list_test.go
@@ -31,7 +31,7 @@ func TestAcc_Cmd_Scenario_List(t *testing.T) {
 		},
 		{
 			dir: "scenario_list_pass_2",
-			out: "SCENARIO \n        \none     \ntwo     \n",
+			out: "SCENARIO \n        \nconsul  \nvault   \n",
 		},
 		{
 			dir:  "scenario_list_fail_malformed",

--- a/internal/flightplan/decoder_test.go
+++ b/internal/flightplan/decoder_test.go
@@ -1,10 +1,13 @@
 package flightplan
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 
 	hcl "github.com/hashicorp/hcl/v2"
 )
@@ -44,31 +47,470 @@ func Test_Decoder_parseDir(t *testing.T) {
 }
 
 func Test_Decoder_Decode(t *testing.T) {
+	t.Parallel()
+
+	modulePath, err := filepath.Abs("./tests/simple_module")
+	require.NoError(t, err)
+
 	for _, test := range []struct {
 		desc     string
 		hcl      string
 		expected *FlightPlan
+		fail     bool
 	}{
 		{
-			desc: "static scenario",
-			hcl:  `scenario "basic" { }`,
+			desc: "simple scenario",
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "basic" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
 			expected: &FlightPlan{
+				Modules: []*Module{
+					{
+						Name:   "backend",
+						Source: modulePath,
+					},
+				},
 				Scenarios: []*Scenario{
 					{
 						Name: "basic",
+						Steps: []*ScenarioStep{
+							{
+								Name: "first",
+								Module: &ScenarioStepModule{
+									Name:   "backend",
+									Source: modulePath,
+								},
+							},
+						},
 					},
 				},
 			},
+		},
+		{
+			desc: "module references",
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+
+  driver = "postgres"
+}
+
+module "frontend_blue" {
+  source = "%[1]s"
+
+  app_version = "1.0.0"
+}
+
+module "frontend_green" {
+  source = "%[1]s"
+
+  app_version = "1.1.0"
+}
+
+module "frontend_red" {
+  source = "hashicorp/qti/frontend-aws"
+
+  version = "2.0.0"
+}
+
+scenario "basic" {
+  step "backend" {
+    module = module.backend
+  }
+
+  step "frontend_blue" {
+    module = module.frontend_blue
+  }
+
+  step "frontend_green" {
+    module = module.frontend_green
+  }
+
+  step "frontend_red" {
+    module = module.frontend_red
+  }
+}
+`, modulePath),
+			expected: &FlightPlan{
+				Modules: []*Module{
+					{
+						Name:   "backend",
+						Source: modulePath,
+						Attrs: map[string]cty.Value{
+							"driver": cty.StringVal("postgres"),
+						},
+					},
+					{
+						Name:   "frontend_blue",
+						Source: modulePath,
+						Attrs: map[string]cty.Value{
+							"app_version": cty.StringVal("1.0.0"),
+						},
+					},
+					{
+						Name:   "frontend_green",
+						Source: modulePath,
+						Attrs: map[string]cty.Value{
+							"app_version": cty.StringVal("1.1.0"),
+						},
+					},
+					{
+						Name:    "frontend_red",
+						Version: "2.0.0",
+						Source:  "hashicorp/qti/frontend-aws",
+					},
+				},
+				Scenarios: []*Scenario{
+					{
+						Name: "basic",
+						Steps: []*ScenarioStep{
+							{
+								Name: "backend",
+								Module: &ScenarioStepModule{
+									Name:   "backend",
+									Source: modulePath,
+								},
+							},
+							{
+								Name: "frontend_blue",
+								Module: &ScenarioStepModule{
+									Name:   "frontend_blue",
+									Source: modulePath,
+								},
+							},
+							{
+								Name: "frontend_green",
+								Module: &ScenarioStepModule{
+									Name:   "frontend_green",
+									Source: modulePath,
+								},
+							},
+							{
+								Name: "frontend_red",
+								Module: &ScenarioStepModule{
+									Name:   "frontend_red",
+									Source: "hashicorp/qti/frontend-aws",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "invalid enos identifier module block",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "hascolon:" {
+  source = "%s"
+}
+
+scenario "basic" {
+  step "first" {
+    module = module.hascolon
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid enos identifier scenario block",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "hascolon:" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid enos identifier scenario step block",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  step "hascolon:" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid block in flight plan",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+notablock "something" {
+  something = "else"
+}
+
+scenario "backend" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid block in scenario",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  notablock "something" {
+    something = "else"
+  }
+
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid block in scenario step",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  step "first" {
+    notablock "something" {
+      something = "else"
+    }
+
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid attr in flightplan",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+notanattr = "foo"
+
+scenario "backend" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid attr in scenario",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  notanattr = "foo"
+
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid attr in scenario step",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  step "first" {
+    notanattr = "foo"
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "count meta-arg attr in module",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+  count = 1
+}
+
+scenario "backend" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "for_each meta-arg attr in module",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+  for_each = toset(["1", "2"])
+}
+
+scenario "backend" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "depends_on meta-arg attr in module",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+module "frontend" {
+  source = "%[1]s"
+  depends_on = module.backend
+}
+
+scenario "backend" {
+  step "first" {
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "count meta-arg attr in step variables",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  step "first" {
+    module = module.backend
+    variables = {
+      count = 1
+    }
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "for_each meta-arg attr in step variables",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  step "first" {
+    variables = {
+      for_each = toset(["1", "2"])
+    }
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "depends_on meta-arg attr in step variables",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+module "frontend" {
+  source = "%[1]s"
+}
+
+scenario "backend" {
+  step "first" {
+    variables = {
+      depends_on = module.backend
+    }
+    module = module.backend
+  }
+}
+`, modulePath),
+		},
+		{
+			desc: "invalid module reference",
+			fail: true,
+			hcl: fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+}
+
+scenario "backend" {
+  step "first" {
+    module = module.not_real
+  }
+}
+`, modulePath),
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			decoder := NewDecoder()
 			diags := decoder.parseHCL([]byte(test.hcl), "decoder-test.hcl")
-			require.False(t, diags.HasErrors())
+			require.False(t, diags.HasErrors(), diags.Error())
 
 			fp, moreDiags := decoder.Decode()
-			require.False(t, moreDiags.HasErrors())
-			require.EqualValues(t, test.expected.Scenarios, fp.Scenarios)
+			if test.fail {
+				require.True(t, moreDiags.HasErrors(), moreDiags.Error())
+			} else {
+				require.False(t, moreDiags.HasErrors(), moreDiags.Error())
+
+				require.Len(t, fp.Modules, len(test.expected.Modules))
+				require.Len(t, fp.Scenarios, len(test.expected.Scenarios))
+
+				for i := range test.expected.Modules {
+					require.EqualValues(t, test.expected.Modules[i].Name, fp.Modules[i].Name)
+					require.EqualValues(t, test.expected.Modules[i].Source, fp.Modules[i].Source)
+					require.EqualValues(t, test.expected.Modules[i].Version, fp.Modules[i].Version)
+					if len(test.expected.Modules[i].Attrs) > 0 {
+						assert.EqualValues(t, test.expected.Modules[i].Attrs, fp.Modules[i].Attrs)
+					}
+				}
+
+				for i := range test.expected.Scenarios {
+					require.EqualValues(t, test.expected.Scenarios[i].Name, fp.Scenarios[i].Name)
+					require.EqualValues(t, test.expected.Scenarios[i].Steps, fp.Scenarios[i].Steps)
+				}
+			}
 		})
 	}
 }

--- a/internal/flightplan/flightplan.go
+++ b/internal/flightplan/flightplan.go
@@ -1,0 +1,224 @@
+package flightplan
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+const (
+	blockTypeModule       = "module"
+	blockTypeScenario     = "scenario"
+	blockTypeScenarioStep = "step"
+)
+
+var flightPlanSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: blockTypeScenario, LabelNames: []string{"name"}},
+		{Type: blockTypeModule, LabelNames: []string{"name"}},
+	},
+}
+
+// NewFlightPlan returns a new instance of a FlightPlan
+func NewFlightPlan() *FlightPlan {
+	return &FlightPlan{
+		Scenarios: []*Scenario{},
+		Modules:   []*Module{},
+	}
+}
+
+// FlightPlan represents our flight plan, the main configuration of Enos.
+type FlightPlan struct {
+	BodyContent *hcl.BodyContent
+	Scenarios   []*Scenario
+	Modules     []*Module
+}
+
+// Decode takes a base eval content and HCL body and decodes it in chunks,
+// continually expanding the evaluation context as more sub-sections are
+// decoded. It returns HCL diagnostics that are collected over the course of
+// decoding.
+func (fp *FlightPlan) Decode(ctx *hcl.EvalContext, body hcl.Body) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	if ctx == nil {
+		ctx = &hcl.EvalContext{
+			Variables: map[string]cty.Value{},
+			Functions: map[string]function.Function{},
+		}
+	}
+
+	// Decode our top-level schema
+	fp.BodyContent, diags = body.Content(flightPlanSchema)
+
+	// decode sub-sections. Each sub-section decoder is responsible for
+	// extending the evaluation context for further evaluation.
+	diags = diags.Extend(fp.decodeModules(ctx))
+	diags = diags.Extend(fp.decodeScenarios(ctx))
+
+	return diags
+}
+
+// decodeModules decodes "module" blocks that are defined in the top-level
+// schema.
+func (fp *FlightPlan) decodeModules(ctx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	mods := map[string]cty.Value{}
+
+	for _, block := range fp.BodyContent.Blocks {
+		if block.Type != blockTypeModule {
+			continue
+		}
+
+		moreDiags := verifyBlockLabelsAreValidIdentifiers(block)
+		diags = diags.Extend(moreDiags)
+		if moreDiags.HasErrors() {
+			continue
+		}
+
+		module := NewModule()
+		moreDiags = module.decode(block, ctx.NewChild())
+		diags = diags.Extend(moreDiags)
+		if moreDiags.HasErrors() {
+			continue
+		}
+
+		fp.Modules = append(fp.Modules, module)
+		mods[module.Name] = module.evalCtx()
+	}
+
+	ctx.Variables["module"] = cty.ObjectVal(mods)
+
+	return diags
+}
+
+// decodeScenarios decodes the "scenario" blocks that are defined in the
+// top-level schema.
+func (fp *FlightPlan) decodeScenarios(ctx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	for _, block := range fp.BodyContent.Blocks {
+		if block.Type != blockTypeScenario {
+			continue
+		}
+
+		moreDiags := verifyBlockLabelsAreValidIdentifiers(block)
+		diags = diags.Extend(moreDiags)
+		if moreDiags.HasErrors() {
+			continue
+		}
+
+		scenario := NewScenario()
+		moreDiags = scenario.decode(block, ctx.NewChild())
+		diags = diags.Extend(moreDiags)
+		if moreDiags.HasErrors() {
+			continue
+		}
+
+		fp.Scenarios = append(fp.Scenarios, scenario)
+	}
+
+	return diags
+}
+
+// filterTerraformMetaAttrs does our best to ensure that the given set of
+// attributes does not include unsupported Terraform meta-args. This is intended
+// to handle cases where we don't know the underlying schema of a blocks attributes
+// is unknown or flexible (e.g. module or scenario step variables) but we still
+// want to make sure that users haven't passed in disallowed meta-args such as
+// count, for_each, and depends_on. Here we'll filter out bad attributes and
+// pass along error diagnostics for any encountered. This allows us to continue
+// to decode in some cases while still bubbling the error up.
+func filterTerraformMetaAttrs(in hcl.Attributes) (hcl.Attributes, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	var out hcl.Attributes
+
+	for name, attr := range in {
+		switch attr.Name {
+		case "count", "for_each", "depends_on":
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "invalid module attribute",
+				Detail:   fmt.Sprintf(`Terraform meta-arguments "%s" are not valid`, attr.Name),
+				Subject:  &attr.NameRange,
+				Context:  &attr.Range,
+			})
+		default:
+			if out == nil {
+				out = hcl.Attributes{}
+			}
+			out[name] = attr
+		}
+	}
+
+	return out, diags
+}
+
+// verifyNoBlockInAttrOnlySchema is a hacky way to ensure that the given block
+// doesn't have any child blocks. As we often have to deal with attribute only
+// blocks which have an unknown schema, this is the only way to ensure those
+// blocks don't have child blocks.
+func verifyNoBlockInAttrOnlySchema(in hcl.Body) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	body, ok := in.(*hclsyntax.Body)
+	if ok && len(body.Blocks) != 0 {
+		for _, block := range body.Blocks {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "invalid block",
+				Detail:   "sub-blocks are not allowed",
+				Subject:  &block.TypeRange,
+			})
+		}
+	}
+
+	return diags
+}
+
+// verifyBlockLabelsAreValidIdentifiers takes and HCL block and validates that
+// the labels conform to both HCL and Enos allowed identifiers.
+func verifyBlockLabelsAreValidIdentifiers(block *hcl.Block) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	if len(block.Labels) == 0 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "invalid scenario block",
+			Detail:   "scenario blocks can only have a single name label",
+			Subject:  &block.TypeRange,
+		})
+
+		return diags
+	}
+
+	for i, label := range block.Labels {
+		// Make sure it's a valid HCL identifier
+		if !hclsyntax.ValidIdentifier(label) {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "block label is invalid",
+				Detail:   "block label is not a valid HCL identifier",
+				Subject:  &block.LabelRanges[i],
+			})
+		}
+
+		// Make sure it also adheres to Enos block name rules
+		r := regexp.MustCompile(`^[\w]+$`)
+		if !r.Match([]byte(label)) {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "block label is invalid",
+				Detail:   "block label is not a valid enos identifier",
+				Subject:  &block.LabelRanges[i],
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/flightplan/module.go
+++ b/internal/flightplan/module.go
@@ -1,0 +1,96 @@
+package flightplan
+
+import (
+	"github.com/zclconf/go-cty/cty"
+
+	hcl "github.com/hashicorp/hcl/v2"
+)
+
+var moduleSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "source", Required: true},
+		{Name: "version"},
+	},
+}
+
+// Module represents an Enos Terraform module block
+type Module struct {
+	Name    string
+	Source  string
+	Version string
+	Attrs   map[string]cty.Value
+}
+
+// NewModule returns a new Module
+func NewModule() *Module {
+	return &Module{
+		Attrs: map[string]cty.Value{},
+	}
+}
+
+// decode takes in an HCL block of a module and an eval context and decodes from
+// the block onto itself. Any errors that are encountered are returned as hcl
+// diagnostics.
+func (m *Module) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	content, remain, moreDiags := block.Body.PartialContent(moduleSchema)
+	diags = diags.Extend(moreDiags)
+	if moreDiags.HasErrors() {
+		return diags
+	}
+
+	m.Name = block.Labels[0]
+	val, moreDiags := content.Attributes["source"].Expr.Value(ctx)
+	diags = diags.Extend(moreDiags)
+	m.Source = val.AsString()
+
+	// "version" isn't required attribute but it is allowed. Handle it manually.
+	version, ok := content.Attributes["version"]
+	if ok {
+		val, moreDiags := version.Expr.Value(ctx)
+		diags = diags.Extend(moreDiags)
+		m.Version = val.AsString()
+	}
+
+	// The remaining portion of our module block is a bunch of attributes
+	// that we'll pass to Terraform in our generated module. We don't know the
+	// schema, nor do we need to, we only need to know the cty.Value of each
+	// attribute.
+	attrs, moreDiags := remain.JustAttributes()
+	diags = diags.Extend(moreDiags)
+	if moreDiags.HasErrors() {
+		return diags
+	}
+
+	attrs, moreDiags = filterTerraformMetaAttrs(attrs)
+	diags = diags.Extend(moreDiags)
+	if moreDiags.HasErrors() {
+		return diags
+	}
+
+	for _, attr := range attrs {
+		m.Attrs[attr.Name], moreDiags = attr.Expr.Value(ctx)
+		diags = diags.Extend(moreDiags)
+	}
+
+	diags = diags.Extend(verifyNoBlockInAttrOnlySchema(remain))
+
+	return diags
+}
+
+// evalCtx returns the module contents as an object cty.Value. We can then
+// embed this into the Variables section of the eval context to allowed method
+// style expression references.
+func (m *Module) evalCtx() cty.Value {
+	vals := map[string]cty.Value{
+		"source": cty.StringVal(m.Source),
+		"name":   cty.StringVal(m.Name),
+	}
+
+	for k, v := range m.Attrs {
+		vals[k] = v
+	}
+
+	return cty.ObjectVal(vals)
+}

--- a/internal/flightplan/module_test.go
+++ b/internal/flightplan/module_test.go
@@ -1,0 +1,64 @@
+package flightplan
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_Module_EvalContext_Functions tests a few built-in functions to ensure
+// that they're available when the module blocks are evaluated.
+func Test_Module_EvalContext_Functions(t *testing.T) {
+	t.Parallel()
+
+	modulePath, err := filepath.Abs("./tests/simple_module")
+	require.NoError(t, err)
+
+	// This isn't an exhaustive test of all functions, but we should have
+	// access to functions in the base resource context.
+	for _, test := range []struct {
+		desc     string
+		expr     string
+		expected string
+	}{
+		{
+			desc:     "upper",
+			expr:     `upper("low")`,
+			expected: "LOW",
+		},
+		{
+			desc:     "trimsuffix",
+			expr:     `trimsuffix("something.com", ".com")`,
+			expected: "something",
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			hcl := fmt.Sprintf(`
+module "backend" {
+  source = "%s"
+  something = %s
+}
+
+scenario "basic" {
+  step "first" {
+    module = module.backend
+  }
+}`, modulePath, test.expr)
+
+			decoder := NewDecoder()
+			diags := decoder.parseHCL([]byte(hcl), "decoder-test.hcl")
+			require.False(t, diags.HasErrors(), diags.Error())
+
+			fp, moreDiags := decoder.Decode()
+			require.False(t, moreDiags.HasErrors(), moreDiags.Error())
+
+			require.Equal(t, 1, len(fp.Modules))
+			v, ok := fp.Modules[0].Attrs["something"]
+			require.True(t, ok)
+
+			require.Equal(t, test.expected, v.AsString())
+		})
+	}
+}

--- a/internal/flightplan/scenario.go
+++ b/internal/flightplan/scenario.go
@@ -1,0 +1,84 @@
+package flightplan
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+)
+
+var scenarioSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: blockTypeScenarioStep, LabelNames: []string{"name"}},
+	},
+}
+
+// Scenario represents an Enos scenario
+type Scenario struct {
+	Name  string
+	Steps []*ScenarioStep
+}
+
+// NewScenario returns a new Scenario
+func NewScenario() *Scenario {
+	return &Scenario{
+		Steps: []*ScenarioStep{},
+	}
+}
+
+// decode takes an HCL block and an evalutaion context and it decodes itself
+// from the block. Any errors that are encountered during decoding will be
+// returned as hcl diagnostics.
+func (s *Scenario) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	content, moreDiags := block.Body.Content(scenarioSchema)
+	diags = diags.Extend(moreDiags)
+	if moreDiags.HasErrors() {
+		return diags
+	}
+
+	s.Name = block.Labels[0]
+
+	// Decode all of our blocks. Make sure that scenario has at least one
+	// step.
+	foundSteps := 0
+	for _, childBlock := range content.Blocks {
+		switch childBlock.Type {
+		case blockTypeScenarioStep:
+			foundSteps++
+			moreDiags = verifyBlockLabelsAreValidIdentifiers(childBlock)
+			diags = diags.Extend(moreDiags)
+			if moreDiags.HasErrors() {
+				continue
+			}
+
+			step := NewScenarioStep()
+			moreDiags = step.decode(childBlock, ctx)
+			diags = diags.Extend(moreDiags)
+			if moreDiags.HasErrors() {
+				continue
+			}
+
+			s.Steps = append(s.Steps, step)
+		default:
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "unknown block in scenario",
+				Detail:   fmt.Sprintf(`unable to parse unknown block "%s" in scenario`, childBlock.Type),
+				Subject:  &childBlock.DefRange,
+			})
+		}
+	}
+
+	if foundSteps == 0 {
+		r := block.Body.MissingItemRange()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "missing required step block",
+			Detail:   "scenarios require one or more step blocks",
+			Subject:  &r,
+		})
+	}
+
+	return diags
+}

--- a/internal/flightplan/scenario_step.go
+++ b/internal/flightplan/scenario_step.go
@@ -1,0 +1,216 @@
+package flightplan
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+
+	hcl "github.com/hashicorp/hcl/v2"
+)
+
+var scenarioStepSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "module", Required: true},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		// NOTE: we don't currently handle variables block
+		{Type: "variables", LabelNames: []string{"name"}},
+	},
+}
+
+// ScenarioStep is a step in an Enos scenario
+type ScenarioStep struct {
+	Name   string
+	Module *ScenarioStepModule
+}
+
+// ScenarioStepModule is the module attribute value in a scenario step
+type ScenarioStepModule struct {
+	Name   string
+	Source string
+	// NOTE: we don't currently handle the extra attributes
+}
+
+// NewScenarioStep returns a new Scenario step
+func NewScenarioStep() *ScenarioStep {
+	return &ScenarioStep{
+		Module: &ScenarioStepModule{},
+	}
+}
+
+// decode takes an HCL block and eval context and decodes itself from the block.
+// It's responsible for ensuring that the block contains a "module" attribute
+// and that it references an existing module that has been previously defined.
+// It performs module reference validation by comparing our module reference
+// to defined modules that are available in the eval context variable"module".
+func (ss *ScenarioStep) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	// Decode the our scenario step
+	content, moreDiags := block.Body.Content(scenarioStepSchema)
+	diags = diags.Extend(moreDiags)
+
+	ss.Name = block.Labels[0]
+
+	// Decode and validate module attribute
+	module, ok := content.Attributes["module"]
+	if !ok {
+		r := block.Body.MissingItemRange()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "scenario step missing module",
+			Detail:   "scenario step missing module",
+			Subject:  &r,
+		})
+
+		return diags
+	}
+
+	// Now that we've found our module attribute we need to decode it and
+	// validate that it's referring to an allowed module, i.e. one that has
+	// been defined at the top-level and has a matching name and source.
+	val, moreDiags := module.Expr.Value(ctx)
+	diags = diags.Extend(moreDiags)
+	if moreDiags.HasErrors() {
+		return diags
+	}
+
+	// Since we don't know the entire schema of the module we cannot use gocty
+	// style struct decoding. We'll have to manually decode the parts that we
+	// do know.
+	if val.IsNull() || !val.IsWhollyKnown() || !val.CanIterateElements() {
+		r := module.Expr.Range()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "invalid module value",
+			Detail:   "module must be a known module object",
+			Subject:  &r,
+		})
+
+		return diags
+	}
+
+	name, ok := val.AsValueMap()["name"]
+	if !ok {
+		r := module.Expr.Range()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "missing module name",
+			Detail:   "missing module name",
+			Subject:  &r,
+		})
+
+		return diags
+	}
+	ss.Module.Name = name.AsString()
+
+	source, ok := val.AsValueMap()["source"]
+	if !ok {
+		r := module.Expr.Range()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "missing module source",
+			Detail:   "missing module source",
+			Subject:  &r,
+		})
+
+		return diags
+	}
+	ss.Module.Source = source.AsString()
+
+	// Now that we know what module we're referencing, make sure that it references
+	// a module that has been defined. We'll do this by going through our eval
+	// context chain until the "module" variable is available. We'll decode it
+	// and try to find a matching module.
+	var modules cty.Value
+	var foundModules bool
+	for modCtx := ctx; modCtx != nil; modCtx = modCtx.Parent() {
+		if modCtx == nil {
+			r := module.Expr.Range()
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "unknown module",
+				Detail:   fmt.Sprintf("a module with name %s has not been defined", ss.Module.Name),
+				Subject:  &r,
+			})
+
+			return diags
+		}
+
+		// Search through all of the eval contexts until we find "modules"
+		m, ok := modCtx.Variables["module"]
+		if ok {
+			modules = m
+			foundModules = true
+			break
+		}
+	}
+
+	if !foundModules {
+		r := module.Expr.Range()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "unknown module",
+			Detail:   "cannot use module as no modules have been found declared",
+			Subject:  &r,
+		})
+
+		return diags
+	}
+
+	foundModuleInCtx := false
+	for _, mod := range modules.AsValueSlice() {
+		name, ok := mod.AsValueMap()["name"]
+		if !ok {
+			// This should never happen
+			continue
+		}
+
+		if name.AsString() != ss.Module.Name {
+			continue
+		}
+
+		source, ok := mod.AsValueMap()["source"]
+		if !ok {
+			r := module.Expr.Range()
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "missing source",
+				Detail:   "module value does not contain a source",
+				Subject:  &r,
+			})
+
+			break
+		}
+
+		if s := source.AsString(); s != ss.Module.Source {
+			r := module.Expr.Range()
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "module source doesn't match module definition",
+				Detail: fmt.Sprintf("module source for module %s is %s, not %s",
+					ss.Module.Name, s, ss.Module.Source,
+				),
+				Subject: &r,
+			})
+			break
+		}
+
+		foundModuleInCtx = true
+		break
+	}
+
+	if !foundModuleInCtx {
+		r := module.Expr.Range()
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "unknown module",
+			Detail:   fmt.Sprintf("a module with name %s has not been defined", ss.Module.Name),
+			Subject:  &r,
+		})
+
+		return diags
+	}
+
+	return diags
+}

--- a/internal/flightplan/tests/simple_module/main.tf
+++ b/internal/flightplan/tests/simple_module/main.tf
@@ -1,0 +1,12 @@
+variable "length" {
+  type = number
+  default = 8
+}
+
+resource "random_string" "cluster_id" {
+  length  = var.length
+  lower   = true
+  upper   = false
+  number  = false
+  special = false
+}


### PR DESCRIPTION
This change extends the Enos DSL with `step` blocks inside `scenario`
blocks. `step` blocks are required to reference a `module` attribute.
Users can now specify module objects as values to the this attribute
either by referencing existing modules through the evaluation context,
or, if for some reason they must, they can build a module object with
`name` and `source` attributes that refer to a defined module. E.g.

```hcl
module "foo" {
  source = "./modules/foo"
}

scenario "test" {
  step "referece_foo" {
    module = module.foo
  }

  // Or
  step "none_reference_foo" {
    module = {
      name   = "foo"
      source = "./modules/foo"
    }
  }
}
```

Scenario step module attibutes must refer to a defined module block or
the decoding pass will fail. A minimally-viable Enos flight plan must
now include a `module`, `scenario`, and `step` with a valid `module`
attribute reference.

We also introduce stdlib[1] functions into base evaluation context that we pass
around everywhere. They use the same single-word, lower-case style as
Terraform.

* Replace `gohcl` struct decoding with `hcl` schema based decoding
* Add stdlib functions to base eval context
* Add scenario step decoding and module reference validation
* Add tests for Terraform meta-args in module blocks
* Add tests for invalid Enos block labels
* Add tests for extraneous blocks in unknown attribute schemas
* Update integration tests for new minimally-viable config

[1] https://pkg.go.dev/github.com/zclconf/go-cty@v1.9.1/cty/function/stdlib

Signed-off-by: Ryan Cragun <me@ryan.ec>