### PR TITLE
[QTI-165] Add step variable support

### DIFF
--- a/acceptance/scenarios/scenario_generate_pass_0/enos.hcl
+++ b/acceptance/scenarios/scenario_generate_pass_0/enos.hcl
@@ -19,6 +19,14 @@ module "bar" {
   anotherinput = "anotherbar"
 }
 
+module "fooref" {
+  source = "./modules/foo"
+}
+
+module "barref" {
+  source = "./modules/bar"
+}
+
 scenario "test" {
   terraform_cli = terraform_cli.debug
 
@@ -44,6 +52,19 @@ scenario "test" {
 
    variables {
       anotherinput = "anotherbarover"
+    }
+  }
+
+  step "fooref" {
+    module = module.fooref
+  }
+
+  step "barref" {
+    module = module.barref
+
+   variables {
+      input        = step.fooref.input
+      anotherinput = step.fooref.anotherinput
     }
   }
 }

--- a/internal/flightplan/eval_context.go
+++ b/internal/flightplan/eval_context.go
@@ -8,6 +8,19 @@ import (
 	hcl "github.com/hashicorp/hcl/v2"
 )
 
+type errNotDefinedInCtx struct {
+	Name string
+	Err  error
+}
+
+func (e *errNotDefinedInCtx) Error() string {
+	return fmt.Sprintf("an eval context variable with name %s has not been defined", e.Name)
+}
+
+func (e *errNotDefinedInCtx) Unwrap() error {
+	return e.Err
+}
+
 func findEvalContextVariable(name string, baseCtx *hcl.EvalContext) (cty.Value, error) {
 	var val cty.Value
 
@@ -27,5 +40,5 @@ func findEvalContextVariable(name string, baseCtx *hcl.EvalContext) (cty.Value, 
 		}
 	}
 
-	return val, fmt.Errorf("an eval context variable with name %s has not been defined", name)
+	return val, &errNotDefinedInCtx{Name: name}
 }

--- a/internal/flightplan/flightplan.go
+++ b/internal/flightplan/flightplan.go
@@ -261,7 +261,7 @@ func (fp *FlightPlan) decodeModules(ctx *hcl.EvalContext) hcl.Diagnostics {
 		}
 
 		fp.Modules = append(fp.Modules, module)
-		mods[module.Name] = module.evalCtx()
+		mods[module.Name] = module.ToCtyValue()
 	}
 
 	ctx.Variables["module"] = cty.ObjectVal(mods)

--- a/internal/flightplan/provider_test.go
+++ b/internal/flightplan/provider_test.go
@@ -192,7 +192,7 @@ scenario "test" {
 									Name:   "test",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("s3"),
+										"driver": testMakeStepVarValue(cty.StringVal("s3")),
 									},
 								},
 								Providers: map[string]*Provider{
@@ -330,7 +330,7 @@ scenario "copy_to_eu" {
 									Name:   "copy",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("s3"),
+										"driver": testMakeStepVarValue(cty.StringVal("s3")),
 									},
 								},
 								Providers: map[string]*Provider{
@@ -379,7 +379,7 @@ scenario "copy_to_eu" {
 									Name:   "copy",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("s3"),
+										"driver": testMakeStepVarValue(cty.StringVal("s3")),
 									},
 								},
 								Providers: map[string]*Provider{

--- a/internal/flightplan/step_variable.go
+++ b/internal/flightplan/step_variable.go
@@ -1,0 +1,181 @@
+package flightplan
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/customdecode"
+)
+
+// StepVariableType is a cty capsule type that represents "step" variables.
+// Step variables might be known values or unknown references to
+// to module outputs. Due to the complex nature of these values we have our
+// cty Type to carry this information for us.
+var StepVariableType cty.Type
+
+// StepVariable is the type encapsulated in StepVariableType
+type StepVariable struct {
+	Value     cty.Value
+	Traversal hcl.Traversal
+}
+
+// StepVariableVal returns a new cty.Value of type StepVariableType
+func StepVariableVal(stepVar *StepVariable) cty.Value {
+	return cty.CapsuleVal(StepVariableType, stepVar)
+}
+
+// StepVariableFromVal returns the *StepVariable from a given value.
+func StepVariableFromVal(v cty.Value) (*StepVariable, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	var stepVar *StepVariable
+
+	if !v.Type().Equals(StepVariableType) {
+		return stepVar, diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "invalid value",
+		})
+	}
+
+	return v.EncapsulatedValue().(*StepVariable), diags
+}
+
+func init() {
+	StepVariableType = cty.CapsuleWithOps("stepvar", reflect.TypeOf(StepVariable{}), &cty.CapsuleOps{
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case customdecode.CustomExpressionDecoder:
+				return customdecode.CustomExpressionDecoderFunc(
+					func(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+						// Step variables are a tricky concept in enos because
+						// we're dealing with either a known input value
+						// or a reference to a Terraform module output which
+						// is unknown. Because unknown reference values are possible
+						// we can't rely on normal expressions evaluation and
+						// instead do a combination of expression evaluation for
+						// known values and static analysis for unknown module
+						// output references. We'll do our best to support complex
+						// references but they have to be absolute traversals to
+						// to "step"'s in the evaluation context.
+						var diags hcl.Diagnostics
+						stepVar := &StepVariable{
+							Value: cty.NilVal,
+						}
+
+						// Try and get an absolute value. This should work if
+						// the value is knowable: an known value of primitive
+						// types or a previously decoded step variable, in the
+						// latter case we really only care about copying the
+						// contents of the value to avoid nesting stepvars.
+						absVal, moreDiags := expr.Value(ctx)
+						if !moreDiags.HasErrors() {
+							// It's an known value. If it's a stepvar get the
+							// value out of it to avoid nesting known stepvars.
+							if absVal.Type().Equals(StepVariableType) {
+								nested, moreDiags := StepVariableFromVal(absVal)
+								diags = diags.Extend(moreDiags)
+								if moreDiags.HasErrors() {
+									return StepVariableVal(stepVar), diags
+								}
+								absVal = nested.Value
+							}
+
+							stepVar.Value = absVal
+							return StepVariableVal(stepVar), diags
+						}
+
+						// We have an unknown value. Let's find out if it's a
+						// valid traversal to another "step".
+						traversal, moreDiags := hcl.AbsTraversalForExpr(expr)
+						if moreDiags.HasErrors() {
+							// If it's not an absolute traversal we can't do
+							// static analysis.
+							return StepVariableVal(stepVar), diags.Extend(moreDiags)
+						}
+
+						// It's an absolute traversal. Find out if it's a valid "step" reference.
+						if traversal.RootName() != "step" {
+							// It's an unknowable value that isn't a reference to
+							// a step output.
+							return StepVariableVal(stepVar), diags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Subject:  traversal.SourceRange().Ptr(),
+								Context:  expr.Range().Ptr(),
+								Summary:  "step variable is unknowable",
+								Detail:   "step variables can only be uknown if the value is a reference to a step module output",
+							})
+						}
+
+						// Make sure we're referencing a known step.
+						steps, err := findEvalContextVariable("step", ctx)
+						if err != nil {
+							return StepVariableVal(stepVar), diags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "no previous steps have been defined",
+								Subject:  traversal.SourceRange().Ptr(),
+								Context:  expr.Range().Ptr(),
+							})
+						}
+
+						stepName, ok := traversal[1].(hcl.TraverseAttr)
+						if !ok {
+							return StepVariableVal(stepVar), diags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "invalid step traversal",
+								Subject:  traversal.SourceRange().Ptr(),
+								Context:  expr.Range().Ptr(),
+							})
+						}
+
+						_, ok = steps.AsValueMap()[stepName.Name]
+						if !ok {
+							return StepVariableVal(stepVar), diags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  fmt.Sprintf("no step named %s has been previously defined", stepName.Name),
+								Subject:  stepName.SourceRange().Ptr(),
+								Context:  traversal.SourceRange().Ptr(),
+							})
+						}
+
+						// Okay, we know that we're referencing a known step but
+						// we don't know about the attribute. That's the best
+						// we can do. Before we return the value we'll rename
+						// the root of the traversal to "module", since that
+						// is really what we're referencing.
+						root, ok := traversal[0].(hcl.TraverseRoot)
+						if !ok {
+							return StepVariableVal(stepVar), diags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "malformed traversal",
+								Subject:  traversal.SourceRange().Ptr(),
+								Context:  expr.Range().Ptr(),
+							})
+						}
+						root.Name = "module"
+						traversal[0] = root
+						stepVar.Traversal = traversal
+
+						return StepVariableVal(stepVar), diags
+					},
+				)
+			default:
+				return nil
+			}
+		},
+		TypeGoString: func(_ reflect.Type) string {
+			return "flightplan.StepVariable"
+		},
+		GoString: func(raw interface{}) string {
+			stepVar, _ := raw.(*StepVariable)
+			return fmt.Sprintf("flightplan.StepVariable(%#v)", stepVar)
+		},
+		RawEquals: func(a, b interface{}) bool {
+			stepVarA, _ := a.(*StepVariable)
+			stepVarB, _ := b.(*StepVariable)
+			return (stepVarA.Value == stepVarB.Value) &&
+				reflect.DeepEqual(stepVarA.Traversal, stepVarB.Traversal)
+		},
+	})
+}

--- a/internal/flightplan/step_variable_capsule_type_test.go
+++ b/internal/flightplan/step_variable_capsule_type_test.go
@@ -1,0 +1,123 @@
+package flightplan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/hashicorp/hcl/v2/hcldec"
+)
+
+func testMakeStepVarTraversal(parts ...string) cty.Value {
+	traversal := hcl.Traversal{}
+	for i, part := range parts {
+		if i == 0 {
+			traversal = append(traversal, hcl.TraverseRoot{Name: part})
+			continue
+		}
+		traversal = append(traversal, hcl.TraverseAttr{Name: part})
+	}
+
+	return StepVariableVal(&StepVariable{Traversal: traversal})
+}
+
+func testMakeStepVarValue(val cty.Value) cty.Value {
+	return StepVariableVal(&StepVariable{Value: val})
+}
+
+func Test_StepVariableType_Decode(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		desc            string
+		body            string
+		ctx             *hcl.EvalContext
+		value           cty.Value
+		expectValue     bool
+		expectTraversal bool
+		fail            bool
+	}{
+		{
+			desc:        "known primitive value",
+			body:        `val = "foo"`,
+			ctx:         &hcl.EvalContext{},
+			expectValue: true,
+			value: cty.ObjectVal(map[string]cty.Value{
+				"val": testMakeStepVarValue(cty.StringVal("foo")),
+			}),
+		},
+		{
+			// this could happen with value chaining through multiple steps
+			desc: "known stepvar value",
+			body: `val = "foo"`,
+			ctx: &hcl.EvalContext{Variables: map[string]cty.Value{
+				"foo": testMakeStepVarValue(cty.StringVal("foo")),
+			}},
+			expectValue: true,
+			value: cty.ObjectVal(map[string]cty.Value{
+				// should inherit the actual value of the capsule
+				"val": testMakeStepVarValue(cty.StringVal("foo")),
+			}),
+		},
+		{
+			desc: "valid absolute traversal ref",
+			body: `val = step.foo.ref.thing`,
+			ctx: &hcl.EvalContext{Variables: map[string]cty.Value{
+				"step": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.ObjectVal(map[string]cty.Value{}),
+				}),
+			}},
+			expectTraversal: true,
+			value:           testMakeStepVarTraversal("module", "foo", "ref", "thing"),
+		},
+		{
+			desc: "no step in context",
+			body: `val = step.foo.ref.thing`,
+			ctx:  &hcl.EvalContext{},
+			fail: true,
+		},
+		{
+			desc: "no matching step in context",
+			body: `val = step.foo.ref.thing`,
+			ctx: &hcl.EvalContext{Variables: map[string]cty.Value{
+				"step": cty.ObjectVal(map[string]cty.Value{
+					"bar": cty.ObjectVal(map[string]cty.Value{}),
+				}),
+			}},
+			fail: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			file, diags := hclsyntax.ParseConfig([]byte(test.body), "", hcl.Pos{Line: 1, Column: 1})
+			if diags.HasErrors() {
+				t.Fatal(diags.Error())
+			}
+			spec := hcldec.ObjectSpec{
+				"val": &hcldec.AttrSpec{
+					Name:     "val",
+					Type:     StepVariableType,
+					Required: true,
+				},
+			}
+
+			val, diags := hcldec.Decode(file.Body, spec, test.ctx)
+			if diags.HasErrors() != test.fail {
+				t.Fatalf("expected: %t, got: %t, err: %s", test.fail, diags.HasErrors(), diags.Error())
+			}
+
+			if test.expectValue {
+				require.EqualValues(t, test.value, val)
+			}
+
+			if test.expectTraversal {
+				attr, ok := val.AsValueMap()["val"]
+				require.True(t, ok, "'val' was not found in the object")
+				testMostlyEqualStepVar(t, test.value, attr)
+			}
+		})
+	}
+}

--- a/internal/flightplan/terraform_cli_test.go
+++ b/internal/flightplan/terraform_cli_test.go
@@ -312,7 +312,7 @@ scenario "debug" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": StepVariableVal(&StepVariable{Value: cty.StringVal("postgres")}),
 									},
 								},
 							},
@@ -328,7 +328,7 @@ scenario "debug" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": StepVariableVal(&StepVariable{Value: cty.StringVal("postgres")}),
 									},
 								},
 							},

--- a/internal/flightplan/terraform_setting_test.go
+++ b/internal/flightplan/terraform_setting_test.go
@@ -343,7 +343,7 @@ scenario "debug" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": testMakeStepVarValue(cty.StringVal("postgres")),
 									},
 								},
 							},
@@ -396,7 +396,7 @@ scenario "debug" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": testMakeStepVarValue(cty.StringVal("postgres")),
 									},
 								},
 							},
@@ -543,7 +543,7 @@ scenario "debug" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": testMakeStepVarValue(cty.StringVal("postgres")),
 									},
 								},
 							},
@@ -590,7 +590,7 @@ scenario "debug" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": testMakeStepVarValue(cty.StringVal("postgres")),
 									},
 								},
 							},
@@ -740,7 +740,7 @@ scenario "experiments" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": testMakeStepVarValue(cty.StringVal("postgres")),
 									},
 								},
 							},
@@ -778,7 +778,7 @@ scenario "experiments" {
 									Name:   "backend",
 									Source: modulePath,
 									Attrs: map[string]cty.Value{
-										"driver": cty.StringVal("postgres"),
+										"driver": testMakeStepVarValue(cty.StringVal("postgres")),
 									},
 								},
 							},


### PR DESCRIPTION
In order to pass information from one step module to another,
we need to be able to pipe the outputs from one generated
Terraform module to another. This change achieves that by
decoding "step" variables as a capsule type and either
saves it as a traversal to a module or the known value.

* Add StepVariable capsule type
* Add tests for decoding the capsule type
* Update scenario step decoding to use the new capsule type
* Add support for validating step variables with references to the
  decoder helpers.
* Add step references to acceptance generation test
* Add generator support for step var types

Signed-off-by: Ryan Cragun <me@ryan.ec>