### PR TITLE
[QTI-236] Resolve non-constant step variable index expressions

### DIFF
--- a/acceptance/scenario_generate_test.go
+++ b/acceptance/scenario_generate_test.go
@@ -24,26 +24,37 @@ func TestAcc_Cmd_Scenario_Generate(t *testing.T) {
 		dir  string
 		args string
 		uid  string
+		noRc bool
 	}{
 		{
 			"scenario_generate_pass_0",
 			"test foo:matrixfoo",
 			fmt.Sprintf("%x", sha256.Sum256([]byte("test [foo:matrixfoo]"))),
+			false,
 		},
 		{
 			"scenario_generate_pass_0",
 			"test foo:matrixbar",
 			fmt.Sprintf("%x", sha256.Sum256([]byte("test [foo:matrixbar]"))),
+			false,
 		},
 		{
 			"scenario_generate_pass_backend",
 			"",
 			fmt.Sprintf("%x", sha256.Sum256([]byte("test"))),
+			false,
 		},
 		{
 			"scenario_generate_pass_cloud",
 			"",
 			fmt.Sprintf("%x", sha256.Sum256([]byte("test"))),
+			false,
+		},
+		{
+			"scenario_generate_step_vars",
+			"step_vars distro:rhel arch:arm",
+			fmt.Sprintf("%x", sha256.Sum256([]byte("step_vars [arch:arm distro:rhel]"))),
+			true,
 		},
 	} {
 		t.Run(fmt.Sprintf("%s %s", test.dir, test.args), func(t *testing.T) {
@@ -62,7 +73,11 @@ func TestAcc_Cmd_Scenario_Generate(t *testing.T) {
 			require.NoError(t, err)
 			s.Close()
 			rc, err := os.Open(filepath.Join(outDir, test.uid, "terraform.rc"))
-			require.NoError(t, err)
+			if test.noRc {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			rc.Close()
 		})
 	}

--- a/acceptance/scenarios/scenario_generate_step_vars/enos.hcl
+++ b/acceptance/scenarios/scenario_generate_step_vars/enos.hcl
@@ -1,0 +1,26 @@
+module "infra" {
+  source = "./modules/infra"
+}
+
+module "target" {
+  source = "./modules/target"
+}
+
+scenario "step_vars" {
+  matrix {
+    distro = ["ubuntu", "rhel"]
+    arch   = ["arm", "amd"]
+  }
+
+  step "infra" {
+    module = module.infra
+  }
+
+  step "target" {
+    module = module.target
+
+    variables {
+      ami = step.infra.amis[matrix.distro][matrix.arch]
+    }
+  }
+}

--- a/acceptance/scenarios/scenario_generate_step_vars/modules/infra/output.tf
+++ b/acceptance/scenarios/scenario_generate_step_vars/modules/infra/output.tf
@@ -1,0 +1,12 @@
+output "amis" {
+  value = {
+    "ubuntu" = {
+      "arm" = "ubuntu-arm"
+      "amd" = "ubuntu-amd"
+    }
+    "rhel" = {
+      "arm" = "rhel-arm"
+      "amd" = "rhel-amd"
+    }
+  }
+}

--- a/acceptance/scenarios/scenario_generate_step_vars/modules/target/input.tf
+++ b/acceptance/scenarios/scenario_generate_step_vars/modules/target/input.tf
@@ -1,0 +1,3 @@
+variable "ami" {
+  type = string
+}


### PR DESCRIPTION
In order to pass information between modules, we have to convert step variable
expressions into absolute traversals if we don't know the value of them.

HCL only supports converting an expression into an absolute traversal if all
traversals have constant keys. This works fine if you use static values, but in
cases where you want to refer to variables or matrix variants it would break,
e.g.:

```hcl
matrix {
  arch   = ["arm64", "amd64"]
  distro = ["rhel", "ubuntu"]
}

step "infra" {
  // Exports an "ami" output that is complex map
}

step "two" {
  variables {
    input = step.one[matrix.distro][matrix.arch]
  }
}
```

Now we attempt to resolve the non-constant keys in index expressions so
that we can render an absolute traversal.

Signed-off-by: Ryan Cragun <me@ryan.ec>

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
