### PR TITLE
add codeowners to protect release dirs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @hashicorp/quality-team
 
 # release configuration
-/.release/                              @hashicorp/release-engineering @hasihcorp/quality-team
+/.release/                              @hashicorp/release-engineering @hashicorp/quality-team
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/quality-team


### PR DESCRIPTION
Per https://hashicorp.atlassian.net/browse/RDX-386 this locks down changes to release directories so that they require approval from release engineering and work with pipeline tooling.