### PR TITLE
basic ui: don't render responses if a prior phase has diags

### DIFF
--- a/acceptance/scenarios/scenario_e2e_aws/enos.hcl
+++ b/acceptance/scenarios/scenario_e2e_aws/enos.hcl
@@ -7,7 +7,7 @@ variable "tags" {
 terraform_cli "default" {
   provider_installation {
     network_mirror {
-      url = "https://enos-provider-current.s3.amazonaws.com/"
+      url     = "https://enos-provider-current.s3.amazonaws.com/"
       include = ["hashicorp.com/qti/enos"]
     }
     direct {
@@ -95,7 +95,7 @@ scenario "e2e" {
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers     = [
+  providers = [
     local.aws_provider[matrix.aws_region],
     local.enos_provider[matrix.distro],
   ]

--- a/internal/ui/basic/show_scenario_destroy.go
+++ b/internal/ui/basic/show_scenario_destroy.go
@@ -15,7 +15,7 @@ func (v *View) ShowScenarioDestroy(res *pb.DestroyScenariosResponse) error {
 		scenario.FromRef(out.GetTerraformModule().GetScenarioRef())
 
 		v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
-		v.writeDestroyResponse(out.GetDestroy())
+		_ = v.writeDestroyResponse(out.GetDestroy())
 	}
 
 	v.WriteDiagnostics(res.GetDiagnostics())

--- a/internal/ui/basic/show_scenario_exec.go
+++ b/internal/ui/basic/show_scenario_exec.go
@@ -15,7 +15,7 @@ func (v *View) ShowScenarioExec(res *pb.ExecScenariosResponse) error {
 		scenario.FromRef(out.GetTerraformModule().GetScenarioRef())
 
 		v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
-		v.writeExecResponse(out.GetSubCommand(), out.GetExec())
+		_ = v.writeExecResponse(out.GetSubCommand(), out.GetExec())
 	}
 
 	v.WriteDiagnostics(res.GetDiagnostics())

--- a/internal/ui/basic/show_scenario_launch.go
+++ b/internal/ui/basic/show_scenario_launch.go
@@ -15,11 +15,13 @@ func (v *View) ShowScenarioLaunch(res *pb.LaunchScenariosResponse) error {
 		scenario.FromRef(out.GetGenerate().GetTerraformModule().GetScenarioRef())
 
 		v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
-		v.writeGenerateResponse(out.GetGenerate())
-		v.writeInitResponse(out.GetInit())
-		v.writeValidateResponse(out.GetValidate())
-		v.writePlanResponse(out.GetPlan())
-		v.writeApplyResponse(out.GetApply())
+		v.writeUntilFailure([]func() bool{
+			v.generateResponseWriter(out.GetGenerate()),
+			v.initResponseWriter(out.GetInit()),
+			v.validateResponseWriter(out.GetValidate()),
+			v.planResponseWriter(out.GetPlan()),
+			v.applyResponseWriter(out.GetApply()),
+		})
 	}
 
 	v.WriteDiagnostics(res.GetDiagnostics())

--- a/internal/ui/basic/show_scenario_output.go
+++ b/internal/ui/basic/show_scenario_output.go
@@ -15,7 +15,7 @@ func (v *View) ShowScenarioOutput(res *pb.OutputScenariosResponse) error {
 		scenario.FromRef(out.GetTerraformModule().GetScenarioRef())
 
 		v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
-		v.writeOutputResponse(out.GetOutput())
+		_ = v.writeOutputResponse(out.GetOutput())
 	}
 
 	v.WriteDiagnostics(res.GetDiagnostics())

--- a/internal/ui/basic/show_scenario_run.go
+++ b/internal/ui/basic/show_scenario_run.go
@@ -15,12 +15,14 @@ func (v *View) ShowScenarioRun(res *pb.RunScenariosResponse) error {
 		scenario.FromRef(out.GetGenerate().GetTerraformModule().GetScenarioRef())
 
 		v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
-		v.writeGenerateResponse(out.GetGenerate())
-		v.writeInitResponse(out.GetInit())
-		v.writeValidateResponse(out.GetValidate())
-		v.writePlanResponse(out.GetPlan())
-		v.writeApplyResponse(out.GetApply())
-		v.writeDestroyResponse(out.GetDestroy())
+		v.writeUntilFailure([]func() bool{
+			v.generateResponseWriter(out.GetGenerate()),
+			v.initResponseWriter(out.GetInit()),
+			v.validateResponseWriter(out.GetValidate()),
+			v.planResponseWriter(out.GetPlan()),
+			v.applyResponseWriter(out.GetApply()),
+			v.destroyResponseWriter(out.GetDestroy()),
+		})
 	}
 
 	v.WriteDiagnostics(res.GetDiagnostics())

--- a/internal/ui/basic/show_scenario_validate.go
+++ b/internal/ui/basic/show_scenario_validate.go
@@ -15,10 +15,12 @@ func (v *View) ShowScenarioValidate(res *pb.ValidateScenariosResponse) error {
 		scenario.FromRef(out.GetGenerate().GetTerraformModule().GetScenarioRef())
 
 		v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
-		v.writeGenerateResponse(out.GetGenerate())
-		v.writeInitResponse(out.GetInit())
-		v.writeValidateResponse(out.GetValidate())
-		v.writePlanResponse(out.GetPlan())
+		v.writeUntilFailure([]func() bool{
+			v.generateResponseWriter(out.GetGenerate()),
+			v.initResponseWriter(out.GetInit()),
+			v.validateResponseWriter(out.GetValidate()),
+			v.planResponseWriter(out.GetPlan()),
+		})
 	}
 
 	v.WriteDiagnostics(res.GetDiagnostics())


### PR DESCRIPTION
This fixes a bug where we'd sometimes erroneously render success
messages for phases when a prior phase had failed.

Signed-off-by: Ryan Cragun <me@ryan.ec>

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
