### PR TITLE
[QTI-258] Handle conditional expressions in step variables

### DIFF
--- a/internal/flightplan/step_variable.go
+++ b/internal/flightplan/step_variable.go
@@ -89,6 +89,10 @@ func absTraversalForExpr(expr hcl.Expression, ctx *hcl.EvalContext) (hcl.Travers
 				Key:      v,
 			}}, traversal...)
 			expr = t.Collection
+		case *hclsyntax.ConditionalExpr:
+			// We've hit some logic that likely points to a traversal. Set our
+			// next expression to the truthy side.
+			expr = t.TrueResult
 		default:
 			// Alright, we can't get an absolute value, an absolute traversal, or
 			// an absolute traversal that's been expanded from the eval context.


### PR DESCRIPTION
When attempting to resolve step variables that are references to other
steps we could only have absolute traversal and index expressions. This
adds support for following truthy conditionals during expression
evaluation.

Signed-off-by: Ryan Cragun <me@ryan.ec>

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
