### PR TITLE
Add missing `contains` function

### DIFF
--- a/internal/flightplan/decoder.go
+++ b/internal/flightplan/decoder.go
@@ -258,6 +258,7 @@ func (d *Decoder) baseEvalContext() *hcl.EvalContext {
 			"strlen":                 stdlib.StrlenFunc,
 			"substr":                 stdlib.SubstrFunc,
 			"subtract":               stdlib.SubtractFunc,
+			"timeadd":                stdlib.TimeAddFunc,
 			"title":                  stdlib.TitleFunc,
 			"trim":                   stdlib.TrimFunc,
 			"trimprefix":             stdlib.TrimPrefixFunc,


### PR DESCRIPTION
### How to read this pull request
Added this because it would be handy to be able to use `contains` in Enos.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [ ] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [ ] I have made necessary changes and/or pull requests for documentation
- [ ] I have written useful comments in the code
