### PR TITLE
DSL: add `file()` to standard eval context

### DIFF
--- a/internal/flightplan/decoder.go
+++ b/internal/flightplan/decoder.go
@@ -123,7 +123,7 @@ func (d *Decoder) baseEvalContext() *hcl.EvalContext {
 		},
 		Functions: map[string]function.Function{
 			"absolute":               stdlib.AbsoluteFunc,
-			"abspath":                funcs.AbsPathFunc,
+			"abspath":                funcs.AbsPathFunc(d.dir),
 			"add":                    stdlib.AddFunc,
 			"and":                    stdlib.AndFunc,
 			"byteslen":               stdlib.BytesLenFunc,
@@ -141,6 +141,7 @@ func (d *Decoder) baseEvalContext() *hcl.EvalContext {
 			"divide":                 stdlib.DivideFunc,
 			"element":                stdlib.ElementFunc,
 			"equal":                  stdlib.EqualFunc,
+			"file":                   funcs.FileFunc,
 			"flatten":                stdlib.FlattenFunc,
 			"floor":                  stdlib.FloorFunc,
 			"format":                 stdlib.FormatFunc,

--- a/internal/flightplan/funcs/filesystem.go
+++ b/internal/flightplan/funcs/filesystem.go
@@ -1,26 +1,39 @@
 package funcs
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
 
-// AbsPathFunc constructs a function that converts a filesystem path to an absolute path
-var AbsPathFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{
-			Name: "path",
-			Type: cty.String,
+// AbsPathFunc constructs a function that converts a filesystem path to an
+// absolute path. It takes basePath that is equal to the decoders working
+// directory, that way relative paths are relative to the working dir.
+func AbsPathFunc(basePath string) function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "path",
+				Type: cty.String,
+			},
 		},
-	},
-	Type: function.StaticReturnType(cty.String),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		absPath, err := filepath.Abs(args[0].AsString())
-		return cty.StringVal(filepath.ToSlash(absPath)), err
-	},
-})
+		Type: function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			path := args[0].AsString()
+			if filepath.IsAbs(path) {
+				return cty.StringVal(filepath.ToSlash(path)), nil
+			}
+
+			if basePath != "" {
+				path = filepath.Join(basePath, path)
+			}
+			absPath, err := filepath.Abs(path)
+			return cty.StringVal(filepath.ToSlash(absPath)), err
+		},
+	})
+}
 
 // JoinPathFunc constructs a function that converts joins two paths
 var JoinPathFunc = function.New(&function.Spec{
@@ -39,5 +52,21 @@ var JoinPathFunc = function.New(&function.Spec{
 		return cty.StringVal(filepath.ToSlash(filepath.Join(
 			args[0].AsString(), args[1].AsString()),
 		)), nil
+	},
+})
+
+// FileFunc reads the contents of the file at the path given. The file must
+// be valid UTF-8.
+var FileFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "path",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		f, err := os.ReadFile(args[0].AsString())
+		return cty.StringVal(string(f)), err
 	},
 })

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "0.0.8"
+	Version = "0.0.9"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
This change makes the `file()` function avaiable in the standard DSL. It
is given a path to a file and it returns the contents as a string.

Signed-off-by: Ryan Cragun <me@ryan.ec>

- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
