### PR TITLE
fmt: always truncate the file when writing format changes

### DIFF
--- a/internal/server/service_v1_format.go
+++ b/internal/server/service_v1_format.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -69,7 +68,7 @@ func (s *ServiceV1) Format(
 		}
 
 		if file.GetPath() != "STDIN" && req.GetConfig().GetWrite() && !req.GetConfig().GetCheck() {
-			f, err := os.OpenFile(file.GetPath(), os.O_RDWR, 0o755)
+			f, err := os.OpenFile(file.GetPath(), os.O_RDWR|os.O_TRUNC, 0o755)
 			if err != nil {
 				res.Diagnostics = diagnostics.FromErr(err)
 				res.Responses = append(res.Responses, r)
@@ -77,7 +76,7 @@ func (s *ServiceV1) Format(
 			}
 			defer f.Close()
 
-			_, err = io.Copy(f, bytes.NewReader(formatted))
+			_, err = f.Write(formatted)
 			if err != nil {
 				res.Diagnostics = diagnostics.FromErr(err)
 				res.Responses = append(res.Responses, r)

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "0.0.9"
+	Version = "0.0.10"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Fix a bug where sometimes the outputted file would have remnants of the old version

Signed-off-by: Ryan Cragun <me@ryan.ec>

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
