### PR TITLE
[QT-330] Only render event diagnostics once

### DIFF
--- a/command/enos/main.go
+++ b/command/enos/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "github.com/hashicorp/enos/internal/command/enos/cmd"
+import (
+	"math/rand"
+	"time"
+
+	"github.com/hashicorp/enos/internal/command/enos/cmd"
+)
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	cmd.Execute()
 }

--- a/internal/ui/basic/show_op_event.go
+++ b/internal/ui/basic/show_op_event.go
@@ -53,6 +53,5 @@ func (v *View) ShowOperationEvent(event *pb.Operation_Event) {
 		)...)
 	}
 
-	v.writeDiags(event.GetDiagnostics(), msg)
 	v.writeMsg(event.GetStatus(), msg.String())
 }

--- a/internal/ui/basic/tf_responses.go
+++ b/internal/ui/basic/tf_responses.go
@@ -169,7 +169,7 @@ func (v *View) writePlainTextResponse(cmd string, stderr string, res status.ResW
 	if status.HasFailed(v.settings.FailOnWarnings, res) {
 		msg := fmt.Sprintf("  %s: failed!", cmd)
 		if v.settings.IsTty {
-			msg = fmt.Sprintf(" %s: ❌", cmd)
+			msg = fmt.Sprintf("  %s: ❌", cmd)
 		}
 		v.ui.Error(msg)
 		if stderr != "" {


### PR DESCRIPTION
* Only render event diagnostics once
* Dynamically update the event responses header based on success or failure

Signed-off-by: Ryan Cragun <me@ryan.ec>
Co-authored-by: Rebecca Willett <rwillett@hashicorp.com>

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
