### PR TITLE
[QT-352] Always output exec information

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -193,7 +193,12 @@ func (r *acceptanceRunner) run(ctx context.Context, subCommand string) ([]byte, 
 	if err != nil {
 		return nil, nil
 	}
-	cmd := exec.CommandContext(ctx, path, strings.Split(subCommand, " ")...)
+
+	cmdParts := strings.Split(subCommand, " ")
+	// Don't specify a port so we can execute tests in parallel
+	cmdParts = append(cmdParts, "--listen-grpc", "http://localhost")
+
+	cmd := exec.CommandContext(ctx, path, cmdParts...)
 	cmd.Env = os.Environ()
 	return cmd.CombinedOutput()
 }

--- a/internal/operation/operator_local.go
+++ b/internal/operation/operator_local.go
@@ -117,8 +117,10 @@ func (o *LocalOperator) Stop() error {
 	defer o.mu.Unlock()
 	o.running = false     // Prevent new work requests from being dispatched
 	o.drainWorkReqQueue() // Drain any queued operations
-	o.ctxCancel()         // Cancel in-flight operations, kill operation workers, drain the event queue
-	o.publisher.Stop()    // Turn off event publisher
+	if o.ctxCancel != nil {
+		o.ctxCancel() // Cancel in-flight operations, kill operation workers, drain the event queue
+	}
+	o.publisher.Stop() // Turn off event publisher
 	return nil
 }
 

--- a/internal/operation/runner_scenario_destroy.go
+++ b/internal/operation/runner_scenario_destroy.go
@@ -94,7 +94,9 @@ func DestroyScenario(req *pb.Operation_Request) WorkFunc {
 
 		// Destroy the scenario
 		resVal.Destroy.Destroy = runner.terraformDestroy(ctx, req, events, state)
-		res.Status = diagnostics.Status(runner.TFConfig.FailOnWarnings, resVal.Destroy.Destroy.GetDiagnostics()...)
+
+		// Determine our final status from all operations
+		res.Status = diagnostics.OperationStatus(runner.TFConfig.FailOnWarnings, res)
 
 		return res
 	}

--- a/internal/operation/runner_scenario_generate.go
+++ b/internal/operation/runner_scenario_generate.go
@@ -38,7 +38,9 @@ func GenerateScenario(req *pb.Operation_Request) WorkFunc {
 		// Run generate and update the generic status
 		resVal := runner.moduleGenerate(ctx, req, events)
 		res.Value = resVal
-		res.Status = diagnostics.Status(runner.TFConfig.FailOnWarnings, resVal.Generate.GetDiagnostics()...)
+
+		// Determine our final status from all operations
+		res.Status = diagnostics.OperationStatus(runner.TFConfig.FailOnWarnings, res)
 
 		return res
 	}

--- a/internal/operation/runner_scenario_output.go
+++ b/internal/operation/runner_scenario_output.go
@@ -39,6 +39,8 @@ func OutputScenario(req *pb.Operation_Request) WorkFunc {
 			WithLogger(log),
 		)
 
+		// Configure the runner with the existing Terraform module. If it doesn't
+		// exit there's nothing to output.
 		mod, diags := moduleForReq(req)
 		resVal.Output.Diagnostics = append(resVal.Output.GetDiagnostics(), diags...)
 
@@ -57,7 +59,9 @@ func OutputScenario(req *pb.Operation_Request) WorkFunc {
 		// Run the output command in the context of the module that should already
 		// exist
 		resVal.Output.Output = runner.terraformOutput(ctx, req, events)
-		res.Status = diagnostics.Status(runner.TFConfig.FailOnWarnings, resVal.Output.Output.GetDiagnostics()...)
+
+		// Determine our final status from all operations
+		res.Status = diagnostics.OperationStatus(runner.TFConfig.FailOnWarnings, res)
 
 		return res
 	}

--- a/internal/ui/basic/show_op_response.go
+++ b/internal/ui/basic/show_op_response.go
@@ -105,9 +105,7 @@ func (v *View) showOperationResponse(res *pb.Operation_Response, fullOnComplete 
 	scenario.FromRef(res.GetOp().GetScenario())
 	v.ui.Info(fmt.Sprintf("Scenario: %s %s", scenario.String(), v.opStatusString(res.GetStatus())))
 
-	// If we have a successful operation and fullOnComplete has not been set to
-	// true we'll move on after printing a single line for the scenario.
-	if res.GetStatus() == pb.Operation_STATUS_COMPLETED && !fullOnComplete {
+	if !shouldShowFullResponse(res, fullOnComplete) {
 		return nil
 	}
 
@@ -161,4 +159,28 @@ func (v *View) showOperationResponse(res *pb.Operation_Response, fullOnComplete 
 	}
 
 	return nil
+}
+
+// shouldShowFullResponse determines whether or not we should display the entire
+// operation response. We show the full response if something went wrong, if
+// a full response has been requested, or if there is operation information for
+// for sub-operations that have output like exec or output.
+func shouldShowFullResponse(res *pb.Operation_Response, fullOnComplete bool) bool {
+	if fullOnComplete {
+		return true
+	}
+
+	if res.GetStatus() != pb.Operation_STATUS_COMPLETED {
+		return true
+	}
+
+	if res.GetExec() != nil {
+		return true
+	}
+
+	if res.GetOutput() != nil {
+		return true
+	}
+
+	return false
 }

--- a/internal/ui/basic/tf_responses.go
+++ b/internal/ui/basic/tf_responses.go
@@ -81,6 +81,7 @@ func (v *View) writeExecResponse(exec *pb.Terraform_Command_Exec_Response) {
 	}
 
 	v.ui.Info(exec.GetStdout())
+	v.ui.Error(exec.GetStderr())
 	v.ui.Debug(fmt.Sprintf("  Sub-command: %s", exec.GetSubCommand()))
 	v.WriteDiagnostics(exec.GetDiagnostics())
 }
@@ -97,7 +98,7 @@ func (v *View) writeOutputResponse(res *pb.Operation_Response) {
 
 	scenario := flightplan.NewScenario()
 	scenario.FromRef(res.GetOp().GetScenario())
-	v.ui.Info(fmt.Sprintf("Scenario: %s", scenario.String()))
+	v.ui.Info(fmt.Sprintf("Scenario: %s %s", scenario.String(), v.opStatusString(res.GetStatus())))
 
 	if status.HasFailed(v.settings.FailOnWarnings, out) {
 		msg := "  Output: failed!"

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "0.0.13"
+	Version = "0.0.14"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
When executing commands that output information we should always display it in the operation summary. This change ensures the `output` and `exec` scenario sub-commands are always displayed in the operation summary in the human readable mode.

* Always display the output of exec sub-commands in the operation status.
* Always configure the exec operation runner with a reference to the scenario Terraform module.
* Bump version
* Use the diagnostics helper function to determine the status for all scenario sub-command operations.
* Update acceptance test runners to use different ports to allow for better parallel acceptance test execution.

Signed-off-by: Ryan Cragun <me@ryan.ec>

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
