### PR TITLE
Fix release workflows to support latest bob CLI

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -53,10 +53,11 @@ jobs:
 
       # Use bob to download artifacts from Artifactory
       - name: Download artifacts
+        env:
+            BOB_ARTIFACTORY_TOKEN: ${{ secrets.QUALITY_TEAM_ARTIFACTORY_TOKEN }}
+            BOB_ARTIFACTORY_USER: ${{ secrets.QUALITY_TEAM_ARTIFACTORY_USER }}
         run: |
           bob download artifactory \
-          -token=${{ secrets.QUALITY_TEAM_ARTIFACTORY_TOKEN }} \
-          -user=${{ secrets.QUALITY_TEAM_ARTIFACTORY_USER }} \
           -channel ${{ env.CHANNEL }} \
           -commit=${{ env.SHA }} \
           -product-name=${{ env.PRODUCT }} \

--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -64,10 +64,11 @@ jobs:
 
       # Use bob to download SHA256SUMS file from Artifactory
       - name: Download artifacts
+         env:
+            BOB_ARTIFACTORY_TOKEN: ${{ secrets.QUALITY_TEAM_ARTIFACTORY_TOKEN }}
+            BOB_ARTIFACTORY_USER: ${{ secrets.QUALITY_TEAM_ARTIFACTORY_USER }}
         run: |
           bob download artifactory \
-          -token=${{ secrets.ARTIFACTORY_TOKEN }} \
-          -user=${{ secrets.ARTIFACTORY_USER }} \
           -channel ${{ inputs.channel }} \
           -commit=${{ inputs.sha }} \
           -product-name=${{ inputs.product }} \


### PR DESCRIPTION
### How to read this pull request
Latest bob CLI does not support `-token` and `-user` as it uses environment variables instead.  So update the release workflows to fix the error

### Checklist
- [x] The commit message includes an explanation of the changes
- [ ] Manual validation of the changes have been performed (if possible)
- [ ] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
