### PR TITLE
[QT-529] Always generate a Terraform configuration files

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -158,7 +158,21 @@ func (g *Generator) TerraformModuleDir() string {
 // file.
 func (g *Generator) generateCLIConfig() error {
 	if g.Scenario.TerraformCLI == nil || g.Scenario.TerraformCLI.ConfigVal.IsNull() {
-		return nil
+		// Always generate a configuration file even if we have not been configured
+		// with any configuration content. Enos scenarios are always configured
+		// with a CLI file so that we don't accidentally inherit something
+		// unexpected from common Terraform configuration directories.
+		// Starting with Terraform 1.4.2 this is actually a requirement as
+		// it will warn if the file override does not exist.
+
+		// Make sure our out directory exists and is a directory
+		err := g.ensureOutDir()
+		if err != nil {
+			return err
+		}
+
+		// Write our RC file to disk
+		return g.write(g.TerraformRCPath(), nil)
 	}
 
 	rc := hclwrite.NewEmptyFile()


### PR DESCRIPTION
Enos scenarios always override the CLI configuration file to ensure that we don't accidentally inherit global configuration. Previously we relied on simply setting the environment variable and geneating actual contents only if they were set in the scenario. Terraform 1.4.2 changed the behavior to warn if the environment variable was set to a non-existent file. Now we always create the file even if it's blank.

### How to read this pull request
You may provide an optional explanation of the best way a review might
approach the changes that are being proposed in this pull request.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
