### PR TITLE
sample list: sort samples by name

### DIFF
--- a/acceptance/scenario_sample_list_test.go
+++ b/acceptance/scenario_sample_list_test.go
@@ -29,12 +29,12 @@ func TestAcc_Cmd_Scenario_Sample_List(t *testing.T) {
 				Samples: []*pb.Ref_Sample{
 					{
 						Id: &pb.Sample_ID{
-							Name: "minimal",
+							Name: "complex",
 						},
 					},
 					{
 						Id: &pb.Sample_ID{
-							Name: "complex",
+							Name: "minimal",
 						},
 					},
 				},

--- a/internal/flightplan/sample_funcs.go
+++ b/internal/flightplan/sample_funcs.go
@@ -132,7 +132,7 @@ func (s *sampleSubsetObsSpec) size() int32 {
 	return s.space + s.taken
 }
 
-// Convert our sample frame into a collection of subsetWithCapSpace that we can use for determine
+// Convert our sample frame into a collection of subset specs that we can use for determine
 // how many elements we should take from each subset.
 func sampleFrameToSubsetSpecs(frame *SampleFrame) []*sampleSubsetObsSpec {
 	subsetSpecs := []*sampleSubsetObsSpec{}

--- a/internal/server/service_v1_list_samples.go
+++ b/internal/server/service_v1_list_samples.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"cmp"
 	"context"
+	"slices"
 
 	"github.com/hashicorp/enos/internal/diagnostics"
 	"github.com/hashicorp/enos/internal/flightplan"
@@ -37,6 +39,10 @@ func (s *ServiceV1) ListSamples(
 		for _, s := range fp.Samples {
 			res.Samples = append(res.Samples, s.Ref())
 		}
+
+		slices.SortStableFunc(res.Samples, func(a, b *pb.Ref_Sample) int {
+			return cmp.Compare(a.GetId().GetName(), b.GetId().GetName())
+		})
 	}
 
 	return res, nil


### PR DESCRIPTION
Always sort the sample list by name rather than the order in which the blocks were decoded.