### PR TITLE
enos generate: fix slow decoding

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,7 @@ linters:
     - goconst
     # disabled for now
     - gocritic
+    - gocyclo
     # disabled for now
     - godox
     - goerr113

--- a/internal/flightplan/scenario_decoder.go
+++ b/internal/flightplan/scenario_decoder.go
@@ -149,6 +149,14 @@ func (d *ScenarioDecoder) DecodeScenarioBlocks(ctx context.Context, blocks []*hc
 
 	scenarioBlocks := d.filterScenarioBlocks(blocks)
 	for i := range scenarioBlocks {
+		// Don't worry about decoding scenario blocks that don't match our name if we've been
+		// given a name.
+		if d.ScenarioFilter != nil && d.ScenarioFilter.Name != "" {
+			if d.ScenarioFilter.Name != scenarioBlocks[i].Name {
+				continue
+			}
+		}
+
 		if d.DecodeTarget >= DecodeTargetScenariosMatrixOnly {
 			var diags hcl.Diagnostics
 			scenarioBlocks[i].Matrix, diags = decodeMatrix(d.EvalContext, scenarioBlocks[i].Block)

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -300,7 +300,7 @@ func (g *Generator) ensureOutDir() error {
 
 // maybeWriteTerraformSettings writes any configured "terraform" settings
 //
-//nolint:cyclop,gocyclo // writing out our terraform settings is complicated.
+//nolint:cyclop // writing out our terraform settings is complicated.
 func (g *Generator) maybeWriteTerraformSettings(rootBody *hclwrite.Body) {
 	s := g.Scenario.TerraformSetting
 	if s == nil {

--- a/internal/operation/flightplan.go
+++ b/internal/operation/flightplan.go
@@ -1,11 +1,8 @@
 package operation
 
 import (
-	"context"
 	"path/filepath"
 
-	"github.com/hashicorp/enos/internal/diagnostics"
-	"github.com/hashicorp/enos/internal/flightplan"
 	"github.com/hashicorp/enos/proto/hashicorp/enos/v1/pb"
 )
 
@@ -19,38 +16,4 @@ func isAbs(path string) (string, error) {
 
 func outDirForWorkspace(w *pb.Workspace) string {
 	return filepath.Join(w.GetFlightplan().GetBaseDir(), ".enos")
-}
-
-func decodeFlightPlan(ctx context.Context, pfp *pb.FlightPlan) (*flightplan.FlightPlan, *pb.DecodeResponse) {
-	res := &pb.DecodeResponse{
-		Diagnostics: []*pb.Diagnostic{},
-	}
-
-	dec, err := flightplan.NewDecoder(
-		flightplan.WithDecoderBaseDir(pfp.GetBaseDir()),
-		flightplan.WithDecoderFPFiles(pfp.GetEnosHcl()),
-		flightplan.WithDecoderVarFiles(pfp.GetEnosVarsHcl()),
-		flightplan.WithDecoderEnv(pfp.GetEnosVarsEnv()),
-	)
-	if err != nil {
-		res.Diagnostics = diagnostics.FromErr(err)
-
-		return nil, res
-	}
-
-	hclDiags := dec.Parse()
-	if len(hclDiags) > 0 {
-		res.Diagnostics = append(res.Diagnostics, diagnostics.FromHCL(dec.ParserFiles(), hclDiags)...)
-	}
-
-	if diagnostics.HasErrors(res.GetDiagnostics()) {
-		return nil, res
-	}
-
-	fp, hclDiags := dec.Decode(ctx)
-	if len(hclDiags) > 0 {
-		res.Diagnostics = append(res.Diagnostics, diagnostics.FromHCL(dec.ParserFiles(), hclDiags)...)
-	}
-
-	return fp, res
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "0.0.20"
+	Version = "0.0.21"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
The module generator operation was still using the old method of decoding whereby we'd decode and validate the entire flightplan before selecting matching scenarios. This updates it to the new lazy decoder that only decodes matching scenarios.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
