### PR TITLE
[QT-420] Ensure that we exit 1 if we exceed our deadline

### DIFF
--- a/acceptance/scenario_run_test.go
+++ b/acceptance/scenario_run_test.go
@@ -44,7 +44,7 @@ func TestAcc_Cmd_Scenario_Run(t *testing.T) {
 
 			enos := newAcceptanceRunner(t, skipUnlessTerraformCLI())
 
-			tmpDir, err := os.MkdirTemp("/tmp", "enos.launch")
+			tmpDir, err := os.MkdirTemp("/tmp", "enos.run")
 			require.NoError(t, err)
 			t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
@@ -111,6 +111,46 @@ func TestAcc_Cmd_Scenario_Run(t *testing.T) {
 			}
 
 			requireEqualOperationResponses(t, expected, out)
+		})
+	}
+}
+
+// TestAcc_Cmd_Scenario_Run_Timeout tests that a scenario that times out should fail.
+func TestAcc_Cmd_Scenario_Run_Timeout(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		dir  string
+		name string
+		uid  string
+	}{
+		{
+			"scenario_run_timeout",
+			"timeout",
+			fmt.Sprintf("%x", sha256.Sum256([]byte("timeout"))),
+		},
+	} {
+		test := test
+		t.Run(fmt.Sprintf("%s %s", test.dir, test.name), func(t *testing.T) {
+			t.Parallel()
+
+			enos := newAcceptanceRunner(t, skipUnlessTerraformCLI())
+
+			tmpDir, err := os.MkdirTemp("/tmp", "enos.run")
+			require.NoError(t, err)
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+			outDir := filepath.Join(tmpDir, test.dir)
+			err = os.MkdirAll(outDir, 0o755)
+			require.NoError(t, err)
+			outDir, err = filepath.EvalSymlinks(outDir)
+			require.NoError(t, err)
+			path, err := filepath.Abs(filepath.Join("./scenarios", test.dir))
+			require.NoError(t, err)
+
+			cmd := fmt.Sprintf("scenario run --chdir %s --out %s --format json --timeout 1s %s", path, outDir, test.name)
+			out, err := enos.run(context.Background(), cmd)
+			require.Error(t, err, string(out))
 		})
 	}
 }

--- a/acceptance/scenarios/scenario_run_timeout/enos.hcl
+++ b/acceptance/scenarios/scenario_run_timeout/enos.hcl
@@ -1,0 +1,9 @@
+module "sleep" {
+  source = "./modules/sleep"
+}
+
+scenario "timeout" {
+  step "sleep" {
+    module = module.sleep
+  }
+}

--- a/acceptance/scenarios/scenario_run_timeout/modules/sleep/main.tf
+++ b/acceptance/scenarios/scenario_run_timeout/modules/sleep/main.tf
@@ -1,0 +1,3 @@
+resource "time_sleep" "wait_5s" {
+  create_duration = "5s"
+}

--- a/internal/flightplan/matrix.go
+++ b/internal/flightplan/matrix.go
@@ -295,6 +295,10 @@ func (v *Vector) EqualUnordered(other *Vector) bool {
 
 // Elements returns a list of the Vectors Elements.
 func (v *Vector) Elements() []Element {
+	if v == nil {
+		return nil
+	}
+
 	return v.elements
 }
 


### PR DESCRIPTION
Fix an issue where we could "successfully fail" by not exiting with 1 in the event that we run over our configured time limit.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
