### PR TITLE
release: maybe fix GH not seeing the tag

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -72,12 +72,14 @@ jobs:
       # pre-release tag as `v<version>-pre+<first 5 characters of SHA>`.
       - name: Create release
         run: |
-          TAG=v${{ env.VERSION }}
+          export TAG=v${{ env.VERSION }}
           PRERELEASE=""
           if [ ${{ env.PRE_RELEASE }} = true ]; then
             PRERELEASE="--prerelease"
             TAG=v${{ env.VERSION }}-pre+$( echo ${{ env.SHA }} | head -c 5 )
           fi
+          export TAG=$TAG
+          export PRERELEASE=$PRERELEASE
           gh release create "$TAG" --target ${{ env.SHA }} --generate-notes "$PRERELEASE" ./.bob/artifacts/*.zip
 
   # If not a pre-release, generate an updated Homebrew formula definition file


### PR DESCRIPTION
gh isn't seeing the value of tag and thus it tries to do an attended install and verify the tag.
https://github.com/hashicorp/enos/actions/runs/6239991420/job/16939145222#step:6:21