### PR TITLE
decode: don't swallow diagnostics when decoding concurrently

### DIFF
--- a/internal/flightplan/scenario_decoder.go
+++ b/internal/flightplan/scenario_decoder.go
@@ -434,4 +434,5 @@ func (d *ScenarioDecoder) decodeScenariosConcurrent(ctx context.Context, sb *Dec
 	cancel()
 	workerWg.Wait()
 	sb.Scenarios = append(sb.Scenarios, scenarios...)
+	sb.Diagnostics = sb.Diagnostics.Extend(diags)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "0.0.24"
+	Version = "0.0.25"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
During our refactor of concurrent decoding we forgot to add diagnostics to our scenario decoder.