### PR TITLE
flightplan: fix various potential nil panics

### DIFF
--- a/acceptance/fmt_test.go
+++ b/acceptance/fmt_test.go
@@ -47,10 +47,12 @@ func TestAcc_Cmd_Fmt(t *testing.T) {
 	got := &pb.FormatResponse{}
 	require.NoErrorf(t, protojson.Unmarshal(out, got), string(out))
 	require.Len(t, got.GetResponses(), len(expected.GetResponses()))
-	for i := range expected.GetResponses() {
-		got := got.GetResponses()[i]
-		expected := expected.GetResponses()[i]
-		require.Equal(t, expected.GetPath(), got.GetPath())
-		require.Equal(t, expected.GetChanged(), got.GetChanged())
+	gotResps := got.GetResponses()
+	require.NotNil(t, gotResps)
+	for i, eRes := range expected.GetResponses() {
+		gotRes := gotResps[i]
+		require.NotNil(t, gotRes)
+		require.Equal(t, eRes.GetPath(), gotRes.GetPath())
+		require.Equal(t, eRes.GetChanged(), gotRes.GetChanged())
 	}
 }

--- a/acceptance/scenario_generate_test.go
+++ b/acceptance/scenario_generate_test.go
@@ -95,14 +95,19 @@ func TestAcc_Cmd_Scenario_Generate(t *testing.T) {
 				})
 			}
 
+			var variants *pb.Matrix_Vector
+			if len(elements) > 0 {
+				variants = &pb.Matrix_Vector{
+					Elements: elements,
+				}
+			}
+
 			scenarioRef := &pb.Ref_Scenario{
 				Id: &pb.Scenario_ID{
-					Name:   test.name,
-					Filter: filter,
-					Uid:    test.uid,
-					Variants: &pb.Matrix_Vector{
-						Elements: elements,
-					},
+					Name:     test.name,
+					Filter:   filter,
+					Uid:      test.uid,
+					Variants: variants,
 				},
 			}
 

--- a/acceptance/scenario_list_test.go
+++ b/acceptance/scenario_list_test.go
@@ -28,10 +28,9 @@ func TestAcc_Cmd_Scenario_List(t *testing.T) {
 			out: &pb.ListScenariosResponse{
 				Scenarios: []*pb.Ref_Scenario{{
 					Id: &pb.Scenario_ID{
-						Name:     "test",
-						Filter:   "test",
-						Uid:      "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-						Variants: &pb.Matrix_Vector{},
+						Name:   "test",
+						Filter: "test",
+						Uid:    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 					},
 				}},
 			},
@@ -42,18 +41,16 @@ func TestAcc_Cmd_Scenario_List(t *testing.T) {
 				Scenarios: []*pb.Ref_Scenario{
 					{
 						Id: &pb.Scenario_ID{
-							Name:     "consul",
-							Uid:      "b713f0bd8f48dfad2263cabc455ade78f7e4e99a548101f31f935686dff67124",
-							Filter:   "consul",
-							Variants: &pb.Matrix_Vector{},
+							Name:   "consul",
+							Uid:    "b713f0bd8f48dfad2263cabc455ade78f7e4e99a548101f31f935686dff67124",
+							Filter: "consul",
 						},
 					},
 					{
 						Id: &pb.Scenario_ID{
-							Name:     "vault",
-							Filter:   "vault",
-							Uid:      "e6f0a1fbb43c89196dcfcbef85908f19ab4c5f7cc4f4c452284697757683d7ef",
-							Variants: &pb.Matrix_Vector{},
+							Name:   "vault",
+							Filter: "vault",
+							Uid:    "e6f0a1fbb43c89196dcfcbef85908f19ab4c5f7cc4f4c452284697757683d7ef",
 						},
 					},
 				},

--- a/internal/command/enos/cmd/fmt.go
+++ b/internal/command/enos/cmd/fmt.go
@@ -146,8 +146,7 @@ func runFmtCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	/// Scan STDIN for content if we've been told to use STDIN either implicitly
-	// of explicitly.
+	// Scan STDIN for content if we've been told to use STDIN either implicitly of explicitly.
 	if (argP == "-" || argP == "") && len(req.GetFiles()) == 0 {
 		bytes, err := io.ReadAll(cmd.InOrStdin())
 		if err != nil {

--- a/internal/flightplan/matrix_test.go
+++ b/internal/flightplan/matrix_test.go
@@ -526,10 +526,19 @@ func Test_Matrix_UniqueValues(t *testing.T) {
 	m2.AddVector(NewVector(NewElement("arch", "arm64"), NewElement("arch", "amd64"), NewElement("arch", "ppc64")))
 
 	uniq := m1.UniqueValues()
-	require.Len(t, uniq.Vectors, len(m2.Vectors))
+	require.Len(t, uniq.GetVectors(), len(m2.GetVectors()))
+	require.NotNil(t, uniq)
 
-	for i := range m2.Vectors {
-		require.EqualValues(t, m2.Vectors[i].elements, uniq.Vectors[i].elements)
+	for i := range m2.GetVectors() {
+		m2Vecs := m2.GetVectors()
+		require.NotNil(t, m2Vecs)
+		m2Vec := m2Vecs[i]
+		require.NotNil(t, m2Vec)
+		uniqVecs := uniq.GetVectors()
+		require.NotNil(t, uniqVecs)
+		uniqVec := uniqVecs[i]
+		require.NotNil(t, uniqVec)
+		require.EqualValues(t, m2Vec.Elements(), uniqVec.Elements())
 	}
 }
 

--- a/internal/flightplan/provider.go
+++ b/internal/flightplan/provider.go
@@ -26,7 +26,7 @@ func NewProvider() *Provider {
 // decodes from the block onto itself. Any errors that are encountered are
 // returned as hcl diagnostics.
 func (p *Provider) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostics {
-	var diags hcl.Diagnostics
+	diags := hcl.Diagnostics{}
 
 	p.Type = block.Labels[0]
 	p.Alias = block.Labels[1]
@@ -34,7 +34,7 @@ func (p *Provider) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostic
 	// Decode the entire provider block as a schemaless block
 	moreDiags := p.Config.Decode(block, ctx)
 	diags = diags.Extend(moreDiags)
-	if moreDiags.HasErrors() {
+	if moreDiags != nil && moreDiags.HasErrors() {
 		return diags
 	}
 

--- a/internal/flightplan/sample_frame_test.go
+++ b/internal/flightplan/sample_frame_test.go
@@ -148,7 +148,7 @@ sample "all" {
 						Id: &pb.Scenario_ID{
 							Name:     "baz",
 							Filter:   "baz",
-							Variants: &pb.Matrix_Vector{Elements: []*pb.Matrix_Element{}},
+							Variants: nil,
 							Uid:      "baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096",
 						},
 					},

--- a/internal/flightplan/sample_funcs.go
+++ b/internal/flightplan/sample_funcs.go
@@ -28,19 +28,18 @@ func SampleFuncAll(ctx context.Context, frame *SampleFrame, r *rand.Rand) (*Samp
 		return nil, fmt.Errorf("filter is incompatible with returning all")
 	}
 
-	res := &SampleObservation{
-		SampleFrame:        frame,
-		SubsetObservations: map[string]*SampleSubsetObservation{},
-	}
-
+	observations := map[string]*SampleSubsetObservation{}
 	for name, subFrame := range frame.SubsetFrames {
-		res.SubsetObservations[name] = &SampleSubsetObservation{
+		observations[name] = &SampleSubsetObservation{
 			SampleSubsetFrame: subFrame,
 			Matrix:            subFrame.Matrix,
 		}
 	}
 
-	return res, nil
+	return &SampleObservation{
+		SampleFrame:        frame,
+		SubsetObservations: observations,
+	}, nil
 }
 
 // SampleFuncPurposiveStratified takes a sample frame and random number generator and returns a new

--- a/internal/flightplan/sample_subset_frame.go
+++ b/internal/flightplan/sample_subset_frame.go
@@ -63,6 +63,10 @@ func (s *SampleSubsetFrame) ObserveSimpleRandom(take int32, r *rand.Rand) (*Samp
 
 // Size returns the total size of elements in the frame.
 func (s *SampleSubsetFrame) Size() int32 {
+	if s == nil {
+		return 0
+	}
+
 	// Don't count blank frames.
 	if s.SampleSubset == nil && s.Matrix == nil {
 		return 0
@@ -70,7 +74,7 @@ func (s *SampleSubsetFrame) Size() int32 {
 
 	// If we have a matrix count one element per vertex
 	if s.Matrix != nil {
-		return int32(len(s.Matrix.Vectors))
+		return int32(len(s.Matrix.GetVectors()))
 	}
 
 	// We don't have a matrix so our size can only be a singular scenario

--- a/internal/flightplan/scenario_decoder.go
+++ b/internal/flightplan/scenario_decoder.go
@@ -128,8 +128,8 @@ func (d DecodedScenarioBlocks) CombinedMatrix() *Matrix {
 		if m == nil {
 			m = sm
 		} else {
-			for j := range sm.Vectors {
-				m.AddVector(sm.Vectors[j])
+			for _, v := range sm.GetVectors() {
+				m.AddVector(v)
 			}
 		}
 	}
@@ -164,10 +164,10 @@ func (d *ScenarioDecoder) DecodeScenarioBlocks(ctx context.Context, blocks []*hc
 			scenarioBlocks[i].Diagnostics = scenarioBlocks[i].Diagnostics.Extend(diags)
 
 			if scenarioBlocks[i].Matrix != nil &&
-				len(scenarioBlocks[i].Matrix.Vectors) > 1 &&
+				len(scenarioBlocks[i].Matrix.GetVectors()) > 1 &&
 				d.ScenarioFilter != nil {
 				scenarioBlocks[i].Matrix = scenarioBlocks[i].Matrix.Filter(d.ScenarioFilter)
-				if scenarioBlocks[i].Matrix == nil || len(scenarioBlocks[i].Matrix.Vectors) < 1 {
+				if scenarioBlocks[i].Matrix == nil || len(scenarioBlocks[i].Matrix.GetVectors()) < 1 {
 					// Our filter has no matches with the scenario filter so there's no need to
 					// try and continue to decode.
 					continue
@@ -181,7 +181,7 @@ func (d *ScenarioDecoder) DecodeScenarioBlocks(ctx context.Context, blocks []*hc
 
 		// Choose which decode option based on our target and the number of variants we have.
 		if scenarioBlocks[i].Matrix == nil ||
-			(scenarioBlocks[i].Matrix != nil && len(scenarioBlocks[i].Matrix.Vectors) < 1) {
+			(scenarioBlocks[i].Matrix != nil && len(scenarioBlocks[i].Matrix.GetVectors()) < 1) {
 			d.decodeScenariosSerial(scenarioBlocks[i])
 		} else {
 			switch d.DecodeTarget {
@@ -297,7 +297,7 @@ func (d *ScenarioDecoder) decodeScenario(
 // and requiring the overhead of goroutines.
 func (d *ScenarioDecoder) decodeScenariosSerial(sb *DecodedScenarioBlock) {
 	// Decode the scenario without a matrix
-	if sb.Matrix == nil || len(sb.Matrix.Vectors) < 1 {
+	if sb.Matrix == nil || len(sb.Matrix.GetVectors()) < 1 {
 		keep, scenario, diags := d.decodeScenario(nil, sb.Block)
 		sb.Diagnostics = sb.Diagnostics.Extend(diags)
 		if keep {
@@ -308,8 +308,8 @@ func (d *ScenarioDecoder) decodeScenariosSerial(sb *DecodedScenarioBlock) {
 	}
 
 	// Decode a scenario for all matrix vectors
-	for i := range sb.Matrix.Vectors {
-		keep, scenario, diags := d.decodeScenario(sb.Matrix.Vectors[i], sb.Block)
+	for i := range sb.Matrix.GetVectors() {
+		keep, scenario, diags := d.decodeScenario(sb.Matrix.GetVectors()[i], sb.Block)
 		sb.Diagnostics = sb.Diagnostics.Extend(diags)
 		if keep {
 			sb.Scenarios = append(sb.Scenarios, scenario)

--- a/internal/flightplan/scenario_output.go
+++ b/internal/flightplan/scenario_output.go
@@ -22,7 +22,7 @@ func NewScenarioOutput() *ScenarioOutput {
 
 // decode takes in an HCL block of an output and unmarshal the value into itself.
 func (v *ScenarioOutput) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostics {
-	var diags hcl.Diagnostics
+	diags := hcl.Diagnostics{}
 	v.Name = block.Labels[0]
 
 	// Define this here so StepVariableType is our cty.Type and not cty.Nil
@@ -46,7 +46,7 @@ func (v *ScenarioOutput) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diag
 
 	val, moreDiags := hcldec.Decode(block.Body, scenarioOutputSpec, ctx)
 	diags = diags.Extend(moreDiags)
-	if moreDiags.HasErrors() {
+	if moreDiags != nil && moreDiags.HasErrors() {
 		return diags
 	}
 

--- a/internal/flightplan/terraform_cli.go
+++ b/internal/flightplan/terraform_cli.go
@@ -160,11 +160,11 @@ func DefaultTerraformCLI() *TerraformCLI {
 // decodes from the block onto itself. Any errors that are encountered are
 // returned as hcl diagnostics.
 func (m *TerraformCLI) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagnostics {
-	var diags hcl.Diagnostics
+	diags := hcl.Diagnostics{}
 
 	content, remain, moreDiags := block.Body.PartialContent(terraformCLISchema)
 	diags = diags.Extend(moreDiags)
-	if moreDiags.HasErrors() {
+	if moreDiags != nil && moreDiags.HasErrors() {
 		return diags
 	}
 
@@ -174,7 +174,7 @@ func (m *TerraformCLI) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagno
 	if ok {
 		val, moreDiags := path.Expr.Value(ctx)
 		diags = diags.Extend(moreDiags)
-		if moreDiags.HasErrors() {
+		if moreDiags != nil && moreDiags.HasErrors() {
 			return diags
 		}
 
@@ -205,9 +205,12 @@ func (m *TerraformCLI) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagno
 
 	env, ok := content.Attributes["env"]
 	if ok {
+		if m.Env == nil {
+			m.Env = map[string]string{}
+		}
 		val, moreDiags := env.Expr.Value(ctx)
 		diags = diags.Extend(moreDiags)
-		if moreDiags.HasErrors() {
+		if moreDiags != nil && moreDiags.HasErrors() {
 			return diags
 		}
 		for k, v := range val.AsValueMap() {
@@ -242,7 +245,7 @@ func (m *TerraformCLI) decode(block *hcl.Block, ctx *hcl.EvalContext) hcl.Diagno
 	// execution.
 	m.ConfigVal, moreDiags = hcldec.Decode(remain, terraformCLISpec, ctx)
 	diags = diags.Extend(moreDiags)
-	if moreDiags.HasErrors() {
+	if moreDiags != nil && moreDiags.HasErrors() {
 		return diags
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "0.0.25"
+	Version = "0.0.26"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
When testing scenario filters with negations for variants that didn't exist for some scenarios, I ran into a panic in the Matrix implementation due to not checking for nil and handling it appropriately in our exclusions. After fixing it I decided to use the `nilaway`[0] static analysis tool to verify the entire `flightplan` package.

The tool itself definitely has a few rough edges, and there were times when it was confused and I had to do things more than once in a function to please it, but overall it found several useful improvements.

It was fairly time consuming so I scoped this to just the `flightplan` package for now. Eventually it might be nice to enable for the entire program but we'd either need to architect away our use of global variables for the UI, server client, and server, or we'd need them to reintroduce per line `//nolint` directives[1].

It also has a few show stopper bugs like not being able to handle listening on a nil channel in a select statement.[2] A tool with a promising and useful future but needs more time for us to enforce.

[0] https://github.com/uber-go/nilaway
[1] https://github.com/uber-go/nilaway/issues/126
[2] https://github.com/uber-go/nilaway/issues/143
