### PR TITLE
Add support for .enos.vars.hcl in user's home directory

### DIFF
--- a/internal/command/enos/cmd/scenario.go
+++ b/internal/command/enos/cmd/scenario.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -229,7 +230,14 @@ func readFlightPlanConfig(dir string, varFilePaths []string) (*pb.FlightPlan, er
 
 	var varsFiles flightplan.RawFiles
 	if len(varFilePaths) == 0 {
-		varsFiles, err = flightplan.FindRawFiles(dir, flightplan.VariablesNamePattern)
+		// Check home directory first and fallback to current directory search.
+		varsFiles, err = flightplan.LoadHomeVarsFile()
+		if err != nil && errors.Is(err, os.ErrNotExist) {
+			varsFiles, err = flightplan.FindRawFiles(dir, flightplan.VariablesNamePattern)
+			if err != nil {
+				return nil, err
+			}
+		}
 	} else {
 		varsFiles, err = flightplan.LoadRawFiles(varFilePaths)
 	}

--- a/internal/flightplan/file_finder.go
+++ b/internal/flightplan/file_finder.go
@@ -15,6 +15,8 @@ var (
 	VariablesNamePattern      = regexp.MustCompile(`^enos[-\w]*?\.vars\.hcl$`)
 )
 
+const variablesHomeFilaname = ".enos.vars.hcl"
+
 // RawFiles are a map of flightplan configuration files and their contents.
 type RawFiles map[string][]byte
 
@@ -91,4 +93,31 @@ func LoadRawFiles(paths []string) (RawFiles, error) {
 	}
 
 	return rawFiles, nil
+}
+
+// LoadHomeVarsFile checks if .enos.vars.hcl exists in $HOME
+// and returns the file if found.
+func LoadHomeVarsFile() (RawFiles, error) {
+	rawFiles := RawFiles{}
+
+	home, _ := os.UserHomeDir()
+	homeVarsFile := filepath.Join(home, variablesHomeFilaname)
+	_, err := os.Stat(homeVarsFile)
+	if err != nil {
+		return rawFiles, err
+	}
+
+	f, err := os.Open(homeVarsFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	bytes, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	rawFiles[homeVarsFile] = bytes
+	return rawFiles, err
 }


### PR DESCRIPTION
This adds support for `$HOME/.enos.vars.hcl` so users can maintain a static vars file. This still supports walking the current directory for vars file, but first checks if the home file exists.

### Checklist
- [X] The commit message includes an explanation of the changes
- [X] Manual validation of the changes have been performed (if possible)
- [X] New or modified code has requisite test coverage (if possible)
- [X] I have performed a self-review of the changes
- [X] I have made necessary changes and/or pull requests for documentation
- [X] I have written useful comments in the code


