### PR TITLE
homebrew: add product label to PR

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -116,5 +116,4 @@ jobs:
           git add Formula/enos.rb
           git commit -m "${{ env.COMMIT_MSG }}"
           git push origin ${{ env.PR_BRANCH }}
-
-          gh pr create --repo ${{ env.TARGET_REPO }} --base ${{ env.BASE_BRANCH }} --head ${{ env.PR_BRANCH }} --title "${{ env.PR_TITLE }}" --body "${{ env.PR_BODY }}" --reviewer ${{ env.REVIEWER }}
+          gh pr create --repo ${{ env.TARGET_REPO }} --base ${{ env.BASE_BRANCH }} --head ${{ env.PR_BRANCH }} --title "${{ env.PR_TITLE }}" --body "${{ env.PR_BODY }}" --reviewer ${{ env.REVIEWER }} --label ${{ inputs.product }}


### PR DESCRIPTION
Add a label to the homebrew PR. This makes it easier to subscribe to PR notifications.