### PR TITLE
homebrew: generate completion for the shell automatically on install

### DIFF
--- a/tools/homebrew/support/enos.rb
+++ b/tools/homebrew/support/enos.rb
@@ -27,6 +27,8 @@ class Enos < Formula
 
   def install
     bin.install "enos"
+
+    generate_completions_from_executable(bin/"enos", "completion")
   end
 
   test do

--- a/tools/homebrew/support/enos.rb.tmpl
+++ b/tools/homebrew/support/enos.rb.tmpl
@@ -27,6 +27,8 @@ class Enos < Formula
 
   def install
     bin.install "enos"
+
+    generate_completions_from_executable(bin/"enos", "completion")
   end
 
   test do


### PR DESCRIPTION
We have support for completion in the binary so we might as well auto-install with homebrew.

I tested this change locally and things work as expected.
![image](https://github.com/hashicorp/enos/assets/65058/e45cff60-e049-471b-b298-4da36572b97f)
