### PR TITLE
outline: use a fluid container for html output format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,7 @@ linters:
     - maintidx
     - maligned
     - musttag
+    - mnd
     - nakedret
     - nestif
     - nonamedreturns

--- a/internal/diagnostics/error.go
+++ b/internal/diagnostics/error.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package diagnostics
 
 import (

--- a/internal/ui/html/template/outline.html.tmpl
+++ b/internal/ui/html/template/outline.html.tmpl
@@ -1,4 +1,4 @@
-<!-- vim: ft=html -->
+<!-- vim: set ft=html: -->
 <!doctype html>
 <html lang="en">
   <head>
@@ -9,7 +9,7 @@
   </head>
   <body>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-    <div class="container">
+    <div class="container-fluid">
       <div class="row gy-5">
         <div class="col-12">
           <div class="p-3">


### PR DESCRIPTION
This just makes the container expand with the size of the window. It looks much better on larger/hidpi screens.
