### PR TITLE
homebrew: the homebrew/tap default branch is master not main

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -56,7 +56,7 @@ jobs:
       GH_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       TARGET_REPO: hashicorp/homebrew-tap
       TARGET_REPO_FILEPATH: homebrew-tap-checkout
-      BASE_BRANCH: main
+      BASE_BRANCH: master
       PR_BRANCH: enos_homebrew_formula_update_v${{ inputs.version }}
       PR_TITLE: "Homebrew formula update for Enos version v${{ inputs.version }}"
       PR_BODY: "This is an automatically generated PR to update the Homebrew formula for Enos after a release has been completed. It must be manually approved and merged by a reviewer."


### PR DESCRIPTION
The workflow is failing since I switched it from the homebrew internal tap to the public tap.
https://github.com/hashicorp/enos/actions/runs/9005482197/job/24740895539#step:8:38

