### PR TITLE
outline: preserve formatting in HTML descriptions

### DIFF
--- a/internal/ui/html/template/outline.html.tmpl
+++ b/internal/ui/html/template/outline.html.tmpl
@@ -29,8 +29,8 @@
                     {{ scenarioName $outline }}
                   </h4>
                   <!-- Description -->
-                  <p class="lead">
-                    {{scenarioDescription $outline}}
+                  <p class="text-wrap text-break">
+                    <span style="white-space:pre">{{ scenarioDescription $outline}}</span>
                   </p>
                   <!-- Variants -->
                   {{ if scenarioVariants $outline}}
@@ -68,7 +68,7 @@
                       <dl class="row">
                         {{with scenarioVerifies $outline}}{{range $i, $quality := .}}
                         <dt class="col-sm-4">{{$quality.Name}}</dt>
-                        <dd class="col-sm-8">{{$quality.Description}}</dd>
+                        <dd class="col-sm-8"><span style="white-space:pre">{{$quality.Description}}</span></dd>
                         {{end}}
                         {{end}}
                       </dl>
@@ -83,7 +83,11 @@
                       {{with scenarioSteps $outline}}{{range $i, $step := .}}
                       <dl class="row">
                         <dt class="col-sm-4">{{$step.Name}}</dt>
-                        <dd class="col-sm-8">{{$step.Description}}</dd>
+                        <dd class="col-sm-8">
+                          <p class="text-wrap text-break">
+                            <span style="white-space:pre">{{$step.Description}}</span>
+                          </p>
+                        </dd>
                         {{ if scenarioStepVerifies $step }}
                           <dt class="col-sm-4"></dt>
                           <dd class="col-sm-8">
@@ -91,7 +95,7 @@
                             <dl class="row">
                               {{with scenarioStepVerifies $step}}{{range $i, $quality := .}}
                               <dt class="col-sm-5">{{$quality.Name}}</dt>
-                              <dd class="col-sm-7">{{$quality.Description}}</dd>
+                              <dd class="col-sm-7"><span style="white-space:pre">{{$quality.Description}}</span></dd>
                               {{end}}
                               {{end}}
                             </dl>


### PR DESCRIPTION
Preserve whitespace and newlines in descriptions when rendering HTML outlines

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
