### PR TITLE
VAULT-28313: Consider available memory when validating samples

### DIFF
--- a/internal/flightplan/scenario_decoder_iterator.go
+++ b/internal/flightplan/scenario_decoder_iterator.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package flightplan
 
 import (

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,0 +1,35 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package memory
+
+import "context"
+
+type Statable interface {
+	Free() uint64
+	Total() uint64
+	Used() uint64
+	Available() uint64
+	String() string
+}
+
+type Config struct {
+	GC bool
+}
+
+type Opt func(*Config)
+
+func WithGC() Opt {
+	return func(c *Config) {
+		c.GC = true
+	}
+}
+
+func DefaultConfig() *Config {
+	return &Config{GC: false}
+}
+
+// Stat gathers memory information from the host system and returns the information.
+func Stat(ctx context.Context, opts ...Opt) (Statable, error) {
+	return stat(ctx, opts...)
+}

--- a/internal/memory/memory_darwin.go
+++ b/internal/memory/memory_darwin.go
@@ -1,0 +1,130 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build darwin
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+var _ Statable = (*DarwinMemory)(nil)
+
+type DarwinMemory struct {
+	free     uint64
+	inactive uint64
+	pageSize uint64
+	memSize  uint64
+}
+
+func stat(ctx context.Context, opts ...Opt) (*DarwinMemory, error) {
+	cfg := DefaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("stat memory: %w", ctx.Err())
+	default:
+	}
+
+	var err error
+	res := &DarwinMemory{}
+	res.pageSize = uint64(unix.Getpagesize())
+	res.memSize, err = unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return nil, err
+	}
+
+	// Set takes a string value, converts it to a uint64, and sets the value
+	set := func(val string, dst *uint64) error {
+		value, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return err
+		}
+		*dst = value * res.pageSize
+
+		return nil
+	}
+
+	if cfg.GC {
+		runtime.GC()
+	}
+
+	cmd := exec.CommandContext(ctx, "vm_stat")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.Split(line, ":")
+		if len(parts) < 2 {
+			continue
+		}
+		k := strings.TrimSpace(parts[0])
+		v := strings.Trim(parts[1], " .")
+		switch k {
+		case "Pages free":
+			if err := set(v, &res.free); err != nil {
+				return nil, err
+			}
+		case "Pages inactive":
+			if err := set(v, &res.inactive); err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+
+	return res, nil
+}
+
+func (m *DarwinMemory) Total() uint64 {
+	if m == nil {
+		return 0
+	}
+
+	return m.memSize
+}
+
+func (m *DarwinMemory) Used() uint64 {
+	if m == nil {
+		return 0
+	}
+
+	return m.memSize - (m.free + m.inactive)
+}
+
+func (m *DarwinMemory) Free() uint64 {
+	if m == nil {
+		return 0
+	}
+
+	return m.free
+}
+
+func (m *DarwinMemory) Available() uint64 {
+	if m == nil {
+		return 0
+	}
+
+	return m.free + m.inactive
+}
+
+func (m *DarwinMemory) String() string {
+	if m == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("Total: %d, Used: %d, Free: %d, Available: %d", m.Total(), m.Used(), m.Free(), m.Available())
+}

--- a/internal/memory/memory_linux.go
+++ b/internal/memory/memory_linux.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"syscall"
+)
+
+var _ Statable = (*LinuxMemory)(nil)
+
+type LinuxMemory struct {
+	*syscall.Sysinfo_t
+}
+
+func stat(ctx context.Context, opts ...Opt) (*LinuxMemory, error) {
+	cfg := DefaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("stat memory: %w", ctx.Err())
+	default:
+	}
+
+	res := &LinuxMemory{
+		Sysinfo_t: &syscall.Sysinfo_t{},
+	}
+
+	if cfg.GC {
+		runtime.GC()
+	}
+
+	return res, syscall.Sysinfo(res.Sysinfo_t)
+}
+
+func (m *LinuxMemory) Total() uint64 {
+	if m == nil || m.Sysinfo_t == nil {
+		return 0
+	}
+
+	return m.Sysinfo_t.Totalram
+}
+
+func (m *LinuxMemory) Used() uint64 {
+	if m == nil || m.Sysinfo_t == nil {
+		return 0
+	}
+
+	return m.Sysinfo_t.Bufferram
+}
+
+func (m *LinuxMemory) Free() uint64 {
+	if m == nil || m.Sysinfo_t == nil {
+		return 0
+	}
+
+	return m.Sysinfo_t.Freeram
+}
+
+func (m *LinuxMemory) Available() uint64 {
+	if m == nil || m.Sysinfo_t == nil {
+		return 0
+	}
+
+	return m.Sysinfo_t.Totalram - m.Sysinfo_t.Bufferram
+}
+
+func (m *LinuxMemory) String() string {
+	if m == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("Total: %d, Used: %d, Free: %d, Available: %d", m.Totalram, m.Bufferram, m.Freeram, m.Available())
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStat(t *testing.T) {
+	t.Parallel()
+
+	out, err := Stat(context.Background(), WithGC())
+	require.NoError(t, err)
+	require.NotEmpty(t, out.String())
+	require.NotZero(t, out.Free())
+	require.NotZero(t, out.Used())
+	require.NotZero(t, out.Total())
+}


### PR DESCRIPTION
Further improve our sample validation by considering our available memory when determining the total number of concurrent workers to make available to our sample validator.

Previously we'd only consider the number of CPU's, which could cause unreliability on machines with less memory than we'd expect.

Follow-up from our changes for scenario decoding here: https://github.com/hashicorp/enos/pull/147

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
