### PR TITLE
actions: update hashicorp/actions-docker-build to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: hashicorp/actions-docker-build@v1
+      - uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
           target: default


### PR DESCRIPTION
Update `hashicorp/actions-docker-build` to `v2` for `actions/upload-artifact` compat.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
