### PR TITLE
Support depending on a skipped step

### DIFF
--- a/internal/flightplan/scenario_step.go
+++ b/internal/flightplan/scenario_step.go
@@ -507,6 +507,7 @@ func (ss *ScenarioStep) decodeAndValidateDependsOn(content *hcl.BodyContent, ctx
 					Subject:  depends.Expr.Range().Ptr(),
 					Context:  depends.Range.Ptr(),
 				})
+				
 				continue
 			}
 
@@ -552,6 +553,7 @@ func (ss *ScenarioStep) decodeAndValidateDependsOn(content *hcl.BodyContent, ctx
 					Subject:  depends.Expr.Range().Ptr(),
 					Context:  depends.Range.Ptr(),
 				})
+				
 				continue
 			}
 


### PR DESCRIPTION
### How to read this pull request
This PR adds support for depending on a skipped step. This allows a user to enforce ordering between steps when the dependent step isn't skipped.  

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [ ] I have made necessary changes and/or pull requests for documentation
- [ ] I have written useful comments in the code