### PR TITLE
updated AWS access key secret and id vars

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,8 +64,8 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           # The github actions service user creds for this account managed in hashicorp/enos-ci
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_09042025 }}
           aws-region: "us-east-1"
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-skip-session-tagging: true


### PR DESCRIPTION
### How to read this pull request
[SECVULN-23992](https://hashicorp.atlassian.net/browse/SECVULN-23992)
The AWS access key that we're currently using for the github_actions-enos IAM user was created over 90 days ago. It should be rotated in order to mitigate against the risks of static credentials associated with using a service user. I have created a new key and added it to this repo's GH Actions Secrets. This PR replaces the old key. Once we have confirmed that introducing the new key hasn't broken anything, the old key will be removed from GH Actions secrets and AWS keys.

### Checklist
- [X] The commit message includes an explanation of the changes
- [ ] Manual validation of the changes have been performed (if possible)
- [ ] New or modified code has requisite test coverage (if possible)
- [X] I have performed a self-review of the changes
- [ ] I have made necessary changes and/or pull requests for documentation
- [ ] I have written useful comments in the code
